### PR TITLE
Fixed access to pages

### DIFF
--- a/modules/pages/content.php
+++ b/modules/pages/content.php
@@ -1,6 +1,5 @@
 <?php
 if (!defined('FLUX_ROOT')) exit;
-$this->loginRequired();
 $pages = Flux::config('FluxTables.CMSPagesTable');
 $path = trim($params->get('path'));
 


### PR DESCRIPTION
There's no sense in require login since is set as AccountLevel::ANYONE on access.php, also this is intended to be used for rules, info, downloads, etc... and users prefer to access this without login. Anyways it still could be changed through access.php
