### PR TITLE
Paypal button language

### DIFF
--- a/data/paypal/button.php
+++ b/data/paypal/button.php
@@ -26,9 +26,8 @@ $itemName           = htmlspecialchars(sprintf('Donation Credits: %s CREDIT(s)',
 <input type="hidden" name="no_note" value="1" />
 <input type="hidden" name="currency_code" value="<?php echo $donationCurrency ?>" />
 <input type="hidden" name="tax" value="0" />
-<input type="hidden" name="lc" value="US" />
 <input type="hidden" name="bn" value="PP-DonationsBF" />
-<p style="text-align: center"><input type="image" src="https://www.paypal.com/en_US/i/btn/btn_donate_LG.gif"
+<p style="text-align: center"><input type="image" src="https://www.paypal.com/<?php Flux::config('DefaultLanguage') ?>/i/btn/btn_donate_LG.gif"
 	name="submit" alt="PayPal - The safer, easier way to pay online!" /></p>
-<img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
+<img alt="" border="0" src="https://www.paypal.com/<?php Flux::config('DefaultLanguage') ?>/i/scr/pixel.gif" width="1" height="1" />
 </form>


### PR DESCRIPTION
To show the button in the same language you've set in config, in format language_country (en_us, es_es, es_ar)
Maybe we should add a warning about the lang file format in application.php...

Also removed the lc value, since it's not needed and Paypal website automatically detects your language.
