### PR TITLE
Follow: 8f95e74 - fixed missing lang support for side and nav bars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /data/jobs/images/M/*.gif
 
 /data/monsters/*.png
+/data/monsters/*.gif
 
 /data/logs/errors
 /data/logs/mail

--- a/themes/bootstrap/header.php
+++ b/themes/bootstrap/header.php
@@ -51,11 +51,11 @@
 							<?php foreach ($menuItems as $menuCategory => $menus): ?>
 								<?php if (!empty($menus)): ?>
 									<li class="dropdown">
-									<a href="#" class="dropdown-toggle" data-toggle="dropdown"><?php echo htmlspecialchars($menuCategory) ?> <b class="caret"></b></a>
+									<a href="#" class="dropdown-toggle" data-toggle="dropdown"><?php echo htmlspecialchars(Flux::message($menuCategory)) ?> <b class="caret"></b></a>
 									<ul class="dropdown-menu">
 									<?php foreach ($menus as $menuItem):  ?>
 										<li>
-											<a href="<?php echo $menuItem['url'] ?>"><?php echo htmlspecialchars($menuItem['name']) ?></a>
+											<a href="<?php echo $menuItem['url'] ?>"><?php echo htmlspecialchars(Flux::message($menuItem['name'])) ?></a>
 										</li>
 									<?php endforeach ?>
 									</ul>
@@ -71,7 +71,7 @@
 									<ul class="dropdown-menu">
 									<?php foreach ($adminMenuItems as $menuItem): ?>
 										<li>
-											<a href="<?php echo $this->url($menuItem['module'], $menuItem['action']) ?>"><?php echo htmlspecialchars($menuItem['name']) ?></a>
+											<a href="<?php echo $this->url($menuItem['module'], $menuItem['action']) ?>"><?php echo htmlspecialchars(Flux::message($menuItem['name'])) ?></a>
 										</li>
 									<?php endforeach ?>
 									</ul>

--- a/themes/bootstrap/main/sidebar.php
+++ b/themes/bootstrap/main/sidebar.php
@@ -18,7 +18,7 @@ $menuItems = $this->getMenuItems();
 			<a href="<?php echo $this->url($menuItem['module'], $menuItem['action']) ?>"<?php
 				if ($menuItem['module'] == 'account' && $menuItem['action'] == 'logout')
 					echo ' onclick="return confirm(\'Are you sure you want to logout?\')"' ?>>
-				<span><?php echo htmlspecialchars($menuItem['name']) ?></span>
+				<span><?php echo htmlspecialchars(Flux::message($menuItem['name'])) ?></span>
 			</a>
 		</td>
 	</tr>
@@ -37,7 +37,7 @@ $menuItems = $this->getMenuItems();
 	<?php foreach ($menuItems as $menuCategory => $menus): ?>
 	<?php if (!empty($menus)): ?>
 	<tr>
-		<th class="menuitem"><strong><?php echo htmlspecialchars($menuCategory) ?></strong></th>
+		<th class="menuitem"><strong><?php echo htmlspecialchars(Flux::message($menuCategory)) ?></strong></th>
 	</tr>
 	<?php foreach ($menus as $menuItem):  ?>
 	<tr>
@@ -45,7 +45,7 @@ $menuItems = $this->getMenuItems();
 			<a href="<?php echo $menuItem['url'] ?>"<?php
 				if ($menuItem['module'] == 'account' && $menuItem['action'] == 'logout')
 					echo ' onclick="return confirm(\'Are you sure you want to logout?\')"' ?>>
-				<span><?php echo htmlspecialchars($menuItem['name']) ?></span>
+				<span><?php echo htmlspecialchars(Flux::message($menuItem['name'])) ?></span>
 			</a>
 		</td>
 	</tr>

--- a/themes/default/main/sidebar.php
+++ b/themes/default/main/sidebar.php
@@ -18,7 +18,7 @@ $menuItems = $this->getMenuItems();
 			<a href="<?php echo $this->url($menuItem['module'], $menuItem['action']) ?>"<?php
 				if ($menuItem['module'] == 'account' && $menuItem['action'] == 'logout')
 					echo ' onclick="return confirm(\'Are you sure you want to logout?\')"' ?>>
-				<span><?php echo htmlspecialchars($menuItem['name']) ?></span>
+				<span><?php echo htmlspecialchars(Flux::message($menuItem['name'])) ?></span>
 			</a>
 		</td>
 	</tr>
@@ -37,7 +37,7 @@ $menuItems = $this->getMenuItems();
 	<?php foreach ($menuItems as $menuCategory => $menus): ?>
 	<?php if (!empty($menus)): ?>
 	<tr>
-		<th class="menuitem"><strong><?php echo htmlspecialchars($menuCategory) ?></strong></th>
+<th class="menuitem"><strong><?php echo htmlspecialchars(Flux::message($menuCategory)) ?></strong></th>
 	</tr>
 	<?php foreach ($menus as $menuItem):  ?>
 	<tr>
@@ -45,7 +45,7 @@ $menuItems = $this->getMenuItems();
 			<a href="<?php echo $menuItem['url'] ?>"<?php
 				if ($menuItem['module'] == 'account' && $menuItem['action'] == 'logout')
 					echo ' onclick="return confirm(\'Are you sure you want to logout?\')"' ?>>
-				<span><?php echo htmlspecialchars($menuItem['name']) ?></span>
+				<span><?php echo htmlspecialchars(Flux::message($menuItem['name'])) ?></span>
 			</a>
 		</td>
 	</tr>


### PR DESCRIPTION
Follow: 8f95e74
1) .gitignore: several servers use gif files, so added to .gitignore.
2) Themes:
- default: Added missing call to labels in sidebar;
- bootstrap: added missing support for lang;   For some reason the upper bar is coded into the header, it was difficult to find.
