### PR TITLE
[super very critical] RCE and Unlimited Credits PayPal vulnerability.

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -101,6 +101,7 @@ return array(
 		//'admin2@localhost',								// -- This array may be empty if you only use one e-mail
 		//'admin3@localhost'								// -- because your Business Email is also checked.
 	),
+	'PaypalHackNotify'          => true,                    // Send email notification if hack attempt detected (Notification will be send for each address in list PayPalBusinessEmail and PayPalReceiverEmails)
 	'GStorageLeaderOnly'		=> false,					// Only allow guild leader to view guild storage rather than all members?
 	'DivorceKeepChild'			=> false,					// Keep child after divorce?
 	'DivorceKeepRings'			=> false,					// Keep wedding rings after divorce?


### PR DESCRIPTION
Checks if payment notify recieved from paypal servers.
Prevent two critical bugs.
Special request to paypal notify with bypass of paypal reciever email
check.
1. Creates executable .php file in payments log folder via
saveDetailsToFile() function.
2. Sending fake completed payment to get unlimited credits.

Hack report example:

https://gist.github.com/S-anasol/9c91d92686bd0e882ee672a394fa1567#file-gistfile1-txt-L45-L48
Highlighted lines is bug execution example.
Bypass paypal email check(receiver_email) and create shell file(txt_id)
with any code inserted into any request variable.