### PR TITLE
itemInfo parsing

### DIFF
--- a/config/access.php
+++ b/config/access.php
@@ -106,7 +106,8 @@ return array(
 			'view'			=> AccountLevel::ANYONE,
 			'add'			=> AccountLevel::ADMIN,
 			'edit'			=> AccountLevel::ADMIN,
-			'copy'			=> AccountLevel::ADMIN
+			'copy'			=> AccountLevel::ADMIN,
+            'iteminfo'		=> AccountLevel::ADMIN
 		),
 		'monster'	=> array(
 			'index'			=> AccountLevel::ANYONE,

--- a/config/application.php
+++ b/config/application.php
@@ -115,6 +115,7 @@ return array(
 	'ItemShopMaxCost'			=> 99,						// Max price an item can be sold for.
 	'ItemShopMaxQuantity'		=> 99,						// Max quantity the item may be sold at once for.
 	'ItemShopItemPerPage'		=> 5,						// The number of items to display per page in the "Item Shop" page.
+    'ShowItemDesc'              => false,                   // Displays generated item descs from parsed itemInfo.lua
 	'HideFromWhosOnline'		=> AccountLevel::LOWGM,		// Levels greater than or equal to this will be hidden from the "Who's Online" page.
 	'HideFromMapStats'			=> AccountLevel::LOWGM,		// Levels greater than or equal to this will be hidden from the "Map Stats" page.
 	'EnableGMPassSecurity'		=> AccountLevel::LOWGM,		// Levels greater than or equal to this will be required to use passwords that meet the earlier GM Password settings.
@@ -379,6 +380,7 @@ return array(
 		'item'			=> array(
 			'index'			=> 'List Items',
 			'add'			=> 'Add Item',
+			'iteminfo'		=> 'Add Item Info',
 		),
 		'pages'			=> array(
 			'index'			=> 'Manage Pages',
@@ -507,6 +509,7 @@ return array(
 		'ServiceDeskCatTable'	=> 'cp_servicedeskcat',
 		'ServiceDeskSettingsTable'	=> 'cp_servicedesksettings',
 		'WebCommandsTable'		=> 'cp_commands',
+        'ItemDescTable'     	=> 'cp_itemdesc',
 	)
 );
 ?>

--- a/data/schemas/charmapdb/cp_itemdesc.20170210033400.sql
+++ b/data/schemas/charmapdb/cp_itemdesc.20170210033400.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS `cp_itemdesc` (
+  `itemid` int(10) unsigned NOT NULL auto_increment,
+  `itemdesc` text NOT NULL,
+  PRIMARY KEY  (`itemid`)
+) ENGINE=MyISAM COMMENT='Stored item descriptions from parsed itemInfo.';

--- a/modules/item/iteminfo.php
+++ b/modules/item/iteminfo.php
@@ -1,0 +1,64 @@
+<?php
+if (!defined('FLUX_ROOT')) exit;
+require_once 'Flux/FileLoad.php';
+$itemDescTable = Flux::config('FluxTables.ItemDescTable');
+$title = 'Item Info';
+$fileLoad = new FileLoad();
+
+// upload and parse map.
+if($files->get('iteminfo')) {
+    $itemInfo = FLUX_ROOT . '/itemInfo.lua';
+    $is_loaded = $fileLoad->load($files->get('iteminfo'), $itemInfo);
+    if($is_loaded === true) {
+        $fp = @fopen($itemInfo, 'r'); 
+        if($fp){ $array = explode("\n", fread($fp, filesize($itemInfo))); }
+        fclose($fp);
+        $ca = count($array);
+        $check = false;
+        for($i=0; $i < $ca; $i++){
+            switch($array[$i]){
+                case (preg_match('/\s{2,}unident/', $array[$i]) ? true : false):
+                    break;
+                case (preg_match('/\s([\[])([0-9]{1,})([\]]) = {/', $array[$i]) ? true : false):
+                    $setid = preg_replace('/\s([\[])([0-9]{1,})([\]]) = {/', '$2', $array[$i]);
+                    break;
+                case (preg_match('/\sidentifiedDescriptionName = {$/', $array[$i]) ? true : false):
+                    $sql="REPLACE INTO {$server->charMapDatabase}.$itemDescTable (`itemid`, `itemdesc`) VALUES ('$setid','";
+                    $check = true;
+                    break;
+                case 'identifiedDescriptionName = {},':
+                    if($check == true){
+                        $sql.="');";
+                        $sth = $server->connection->getStatement($sql);
+                        $sth->execute();
+                        $check = false;
+                    }
+                    break;
+                case (preg_match('/(.*?)(\")(.*?)(\^)([0-9a-fA-F]{6})(.*?)(\^0{6})(.*?)\"(,?)/', $array[$i]) ? true : false):
+                    $array[$i] = preg_replace('/(.*?)(\")(.*?)(\^)([0-9a-fA-F]{6})(.*?)(\^0{6})(.*?)\"(,?)/', '$3<font color="#$5">$6</font>$8<br />', $array[$i]);
+                case (preg_match('/\s{2,}(\")(.*?)\"(,?)/', $array[$i]) ? true : false):
+                    if($check == true){
+                        $sqlp = preg_replace('/\s{2,}(\")(.*?)\"(,?)/', '$2<br />', $array[$i]);
+                        $sql.= addslashes($sqlp);
+                    }
+                    break;
+                case (preg_match('/\s{2,}},/', $array[$i]) ? true : false):
+                    if($check == true){
+                        $sql.="');";
+                        $sth = $server->connection->getStatement($sql);
+                        $sth->execute();
+                        $check = false;
+                    }
+                default:
+                    break;
+            }
+        }
+        $fileLoad->delete();
+    } else {
+        $errorMessage = $is_loaded;
+    }
+}
+
+$sth = $server->connection->getStatement("SELECT COUNT(itemid) AS count FROM {$server->charMapDatabase}.$itemDescTable");
+$sth->execute();
+$return = $sth->fetch();

--- a/modules/item/view.php
+++ b/modules/item/view.php
@@ -15,6 +15,7 @@ if($server->isRenewal) {
 $tableName = "{$server->charMapDatabase}.items";
 $tempTable = new Flux_TemporaryTable($server->connection, $tableName, $fromTables);
 $shopTable = Flux::config('FluxTables.ItemShopTable');
+$itemDescTable = Flux::config('FluxTables.ItemDescTable');
 
 $itemID = $params->get('id');
 
@@ -39,10 +40,16 @@ $col .= 'equip_jobs, equip_upper, equip_genders, equip_locations, ';
 $col .= 'weapon_level, equip_level AS equip_level_min, refineable, view, script, ';
 $col .= 'equip_script, unequip_script, origin_table, ';
 $col .= "$shopTable.cost, $shopTable.id AS shop_item_id, ";
+if(Flux::config('ShowItemDesc')){
+    $col .= 'itemdesc, ';
+}
 $col .= $server->isRenewal ? '`atk:matk` AS attack' : 'attack';
 
 $sql  = "SELECT $col FROM {$server->charMapDatabase}.items ";
 $sql .= "LEFT OUTER JOIN {$server->charMapDatabase}.$shopTable ON $shopTable.nameid = items.id ";
+if(Flux::config('ShowItemDesc')){
+    $sql .= "LEFT OUTER JOIN {$server->charMapDatabase}.$itemDescTable ON $itemDescTable.itemid = items.id ";
+}
 $sql .= "WHERE items.id = ? LIMIT 1";
 
 $sth  = $server->connection->getStatement($sql);

--- a/themes/default/item/iteminfo.php
+++ b/themes/default/item/iteminfo.php
@@ -1,0 +1,15 @@
+<?php if (!empty($errorMessage)): ?>
+    <p class="red"><?php echo htmlspecialchars($errorMessage) ?></p>
+<?php endif ?>
+<?php if (!empty($successMessage)): ?>
+    <p class="green"><?php echo htmlspecialchars($successMessage) ?></p>
+<?php endif ?>
+
+<h3>Upload itemInfo.lua</h3>
+<form class="forms" method="post" enctype="multipart/form-data">
+    <input type="file" name="iteminfo"><br>
+    <input class="btn" type="submit">
+</form>
+
+<h3>Current Count</h3>
+<p>There are currently <?php echo number_format($return->count) ?> item descriptions in the database</p>

--- a/themes/default/item/view.php
+++ b/themes/default/item/view.php
@@ -178,6 +178,19 @@
 		</td>
 	</tr>
 	<?php endif ?>
+    <?php if(Flux::config('ShowItemDesc')):?>
+	<tr>
+		<th>Description</th>
+		<td colspan="<?php echo $image ? 4 : 3 ?>">
+			<?php if($item->itemdesc): ?>
+                <?php echo $item->itemdesc ?>
+            <?php else: ?>
+                <span class="not-applicable">Unknown</span>
+			<?php endif ?>
+		</td>
+	</tr>
+    <?php endif ?>
+    
 </table>
 <?php if ($itemDrops): ?>
 <h3><?php echo htmlspecialchars($item->name) ?> Dropped By</h3>


### PR DESCRIPTION
* Config 'ShowItemDesc' in application.php defaults to false. Change to true in order to use.
* New SQL file `cp_itemdesc` in the charDB schema.
* Tested with itemInfo.lua from https://github.com/zackdreaver/ROenglishRE/ but assuming the format is the same, it should work with files sourced from other locations.
* Regex could possibly do with sharpening up a little.
* Remember to ensure that your PHP post_max_size is large enough to accomodate your file.
* Not the best implementation, but it works.
* Todays regex headache is thanks to @hurtsky for the suggestion.

Signed-off-by: Akkarinage <akkarin@rathena.org>