### PR TITLE
Increased datasize for address_status

### DIFF
--- a/data/schemas/logindb/cp_txnlog.20170221184601.sql
+++ b/data/schemas/logindb/cp_txnlog.20170221184601.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `cp_txnlog` CHANGE `address_status` `address_status` VARCHAR(11) CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL;


### PR DESCRIPTION
The returned string for "address_status" contains either confirmed (9 chars) or unconfirmed (11 chars)

Signed-off-by: Akkarinage <akkarin@rathena.org>