### PR TITLE
Fixed vanishing heads

### DIFF
--- a/lib/Flux/Athena.php
+++ b/lib/Flux/Athena.php
@@ -653,7 +653,7 @@ class Flux_Athena {
 		}
 		
 		$sql  = "UPDATE {$this->charMapDatabase}.`char` SET ";
-		$sql .= "hair = 0, hair_color = 0, clothes_color = 0, weapon = 0, shield = 0, ";
+		$sql .= "hair = 1, hair_color = 0, clothes_color = 0, weapon = 0, shield = 0, ";
 		$sql .= "head_top = 0, head_mid = 0, head_bottom = 0 ";
 		$sql .= "WHERE char_id = ?";
 		$sth  = $this->connection->getStatement($sql);


### PR DESCRIPTION
Using the default Stylist resets chars back to hair 1, hcolor 1, cloth 1.
New char defaults to hair 1, hcolor 0, cloth 0.
FluxCP set all to 0, which is no good as hair 1 is the lowest value.
Changed resetLook to mimic new char values. Closes #122.

Signed-off-by: Akkarinage <akkarin@rathena.org>