### PR TITLE
CashShop Module

### DIFF
--- a/config/access.php
+++ b/config/access.php
@@ -44,6 +44,12 @@ return array(
 			'delete'   => AccountLevel::ADMIN,
 			'imagedel' => AccountLevel::ADMIN
 		),
+		'cashshop'  => array(
+			'index'    => AccountLevel::ADMIN,
+			'add'      => AccountLevel::ADMIN,
+			'edit'     => AccountLevel::ADMIN,
+			'delete'   => AccountLevel::ADMIN
+		),
 		'account'   => array(
 			'index'    => AccountLevel::LOWGM,
 			'view'     => AccountLevel::NORMAL,
@@ -228,6 +234,7 @@ return array(
 		'AddShopItem'		=> AccountLevel::ADMIN,  // Ability to add an item to the shop.
 		'EditShopItem'		=> AccountLevel::ADMIN,  // Ability to modify a shop item's details.
 		'DeleteShopItem'     => AccountLevel::ADMIN,  // Ability to remove an item for sale on the shop.
+		'ManageCashShop'     => AccountLevel::ADMIN,  // Ability to manage the in-game cash shop.
 		'ViewGuild'          => AccountLevel::ADMIN,  // Ability to view another guild's details.
 		'SearchWhosOnline'   => AccountLevel::ANYONE, // Ability to search the "Who's Online" page.
 		'ViewOnlinePosition' => AccountLevel::LOWGM,  // Ability to see a character's current map on "Who's Online" page.

--- a/config/application.php
+++ b/config/application.php
@@ -287,6 +287,7 @@ return array(
 			'SendMailLabel'		=> array('module' => 'mail'),
 			'WCTitleLabel'		=> array('module' => 'webcommands'),
 			'Map Database Edit' => array('module' => 'admin_spawn'),
+			'Cash Shop'			=> array('module' => 'cashshop'),
 			//'Auction'		=> array('module' => 'auction'),
 			//'Economy'		=> array('module' => 'economy')
 		)
@@ -480,6 +481,9 @@ return array(
 
 	// Item shop categories.
 	'ShopCategories'				=> include('shopcategories.php'),
+
+	// Cash shop categories.
+	'CashShopCategories'			=> include('cashshopcategories.php'),
 
 	// Item pick and zeny log types.
 	'PickTypes'						=> include('picktypes.php'),

--- a/config/cashshopcategories.php
+++ b/config/cashshopcategories.php
@@ -1,0 +1,19 @@
+<?php
+// These are categories for the cash shop. Pay close attention to the numbers,
+// as these numbers are stored in the database when you add an item to a specific
+// category, so it knows which category the item belongs to.
+
+// Keep in mind that different texture files will display different categories in-game.
+// These are the same used in rAthena's db files.
+return array(
+	0 => 'New',
+	1 => 'Hot',
+	2 => 'Limited',
+	3 => 'Rental',
+	4 => 'Gear',
+	5 => 'Buff',
+	6 => 'Heal',
+	7 => 'Other',
+	7 => 'Sale'
+);
+?>

--- a/lib/Flux/CashShop.php
+++ b/lib/Flux/CashShop.php
@@ -1,0 +1,102 @@
+<?php
+require_once 'Flux/TemporaryTable.php';
+require_once 'Flux/ItemExistsError.php';
+
+class Flux_CashShop {
+	/**
+	 * @access public
+	 * @var Flux_Athena
+	 */
+	public $server;
+	
+	public function __construct(Flux_Athena $server) {
+		$this->server = $server;
+	}
+	
+	/**
+	 * Add an item to the cash shop.
+	 */
+	public function add($tab, $itemID, $price) {
+		$db    = $this->server->charMapDatabase;
+		$sql   = "INSERT INTO $db.`item_cash_db` (tab, item_id, price) VALUES (?, ?, ?)";
+		$sth   = $this->server->connection->getStatement($sql);
+		$res   = $sth->execute(array($tab, $itemID, $price));
+		
+		if ($res) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	/**
+	 * Modify item info in the shop.
+	 */
+	public function edit($shopItemID, $tab = null, $price = null) {
+		$tabQ = '';
+		$priceQ = '';
+		$bind = array();
+		
+		if (!is_null($tab)) {
+			$tabQ   = "tab = ? ";
+			$bind[] = (int)$tab;
+		}
+		
+		if (!is_null($price)) {
+			if ($tabQ) {
+				$priceQ   = ", price = ? ";
+			} else {
+				$priceQ   = "price = ? ";
+			}
+			$bind[] = (int)$price;
+		}
+		
+		if (empty($bind)) { return false; }
+		
+		$db    = $this->server->charMapDatabase;
+		$sql   = "UPDATE $db.`item_cash_db` SET $tabQ $priceQ WHERE item_id = ?";
+		$sth   = $this->server->connection->getStatement($sql);
+		
+		$bind[] = $shopItemID;
+		return $sth->execute($bind);
+	}
+	
+	/**
+	 *
+	 */
+	public function delete($ItemID) {
+		$db    = $this->server->charMapDatabase;
+		$sql   = "DELETE FROM $db.`item_cash_db` WHERE item_id = ?";
+		$sth   = $this->server->connection->getStatement($sql);
+		
+		return $sth->execute(array($ItemID));
+	}
+	
+	/**
+	 *
+	 */
+	public function getItem($shopItemID) {
+		$db = $this->server->charMapDatabase;
+		
+		if($this->server->isRenewal) {
+			$fromTables = array("$db.item_db_re", "$db.item_db2_re");
+		} else {
+			$fromTables = array("$db.item_db", "$db.item_db2");
+		}
+		
+		$temp  = new Flux_TemporaryTable($this->server->connection, "$db.items", $fromTables);
+		$shop  = 'item_cash_db';
+		$col   = "$shop.item_id AS shop_item_id, $shop.tab AS shop_item_tab, $shop.price AS shop_item_price, ";
+		$col  .= "items.name_japanese AS shop_item_name";
+		$sql   = "SELECT $col FROM $db.$shop LEFT OUTER JOIN $db.items ON items.id = $shop.item_id WHERE $shop.item_id = ?";
+		$sth   = $this->server->connection->getStatement($sql);
+		
+		if ($sth->execute(array($shopItemID))) {
+			return $sth->fetch();
+		} else {
+			return false;
+		}
+	}
+
+}
+?>

--- a/modules/cashshop/add.php
+++ b/modules/cashshop/add.php
@@ -1,0 +1,52 @@
+<?php
+if (!defined('FLUX_ROOT')) exit; 
+
+$this->loginRequired();
+
+if (!$auth->allowedToManageCashShop) {
+	$this->deny();
+}
+$title = 'Add Item to Cash Shop';
+
+require_once 'Flux/TemporaryTable.php';
+require_once 'Flux/CashShop.php';
+
+$itemID = $params->get('id');
+
+$category   = null;
+$categories = Flux::config('CashShopCategories')->toArray();
+
+if($server->isRenewal) {
+	$fromTables = array("{$server->charMapDatabase}.item_db_re", "{$server->charMapDatabase}.item_db2_re");
+} else {
+	$fromTables = array("{$server->charMapDatabase}.item_db", "{$server->charMapDatabase}.item_db2");
+}
+$tableName = "{$server->charMapDatabase}.items";
+$tempTable = new Flux_TemporaryTable($server->connection, $tableName, $fromTables);
+
+$col = "id AS item_id, name_japanese AS item_name, type";
+$sql = "SELECT $col FROM $tableName WHERE items.id = ?";
+$sth = $server->connection->getStatement($sql);
+
+$sth->execute(array($itemID));
+$item = $sth->fetch();
+
+if ($item && count($_POST)) {
+	$tab         = $params->get('tab');
+	$shop        = new Flux_CashShop($server);
+	$price       = (int)$params->get('price');
+	
+	if (!$price) {
+		$errorMessage = 'You must input a cashpoint cost greater than zero.';
+	} else {
+		if ($shop->add($tab, $itemID, $price)) {
+			$message = 'Item has been successfully added to the CashShop';
+			$session->setMessageData($message);
+			$this->redirect($this->url('cashshop'));
+		} else {
+			$errorMessage = 'Failed to add the item to the CashShop.';
+		}
+	}
+}
+
+?>

--- a/modules/cashshop/delete.php
+++ b/modules/cashshop/delete.php
@@ -1,0 +1,20 @@
+<?php
+if (!defined('FLUX_ROOT')) exit;
+
+$this->loginRequired();
+
+if (!$auth->allowedToManageCashShop) {
+	$this->deny();
+}
+
+require_once 'Flux/CashShop.php';
+
+$shop       = new Flux_CashShop($server);
+$shopItemID = $params->get('id');
+$deleted    = $shopItemID ? $shop->delete($shopItemID) : false;
+
+if ($deleted) {
+	$session->setMessageData('Item successfully deleted from the CashShop. You will need to reload your itemdb for this to take effect in-game.');
+	$this->redirect($this->url('cashshop'));
+}
+?>

--- a/modules/cashshop/edit.php
+++ b/modules/cashshop/edit.php
@@ -1,0 +1,59 @@
+<?php
+if (!defined('FLUX_ROOT')) exit; 
+
+$this->loginRequired();
+
+if (!$auth->allowedToManageCashShop) {
+	$this->deny();
+}
+$title = 'Modify Item in the CashShop';
+
+require_once 'Flux/TemporaryTable.php';
+require_once 'Flux/CashShop.php';
+
+$shopItemID  = $params->get('id');
+$shop        = new Flux_CashShop($server);
+$tabs        = Flux::config('CashShopCategories')->toArray();
+$item        = $shop->getItem($shopItemID);
+
+if ($item) {
+	if($server->isRenewal) {
+		$fromTables = array("{$server->charMapDatabase}.item_db_re", "{$server->charMapDatabase}.item_db2_re");
+	} else {
+		$fromTables = array("{$server->charMapDatabase}.item_db", "{$server->charMapDatabase}.item_db2");
+	}
+	$tableName = "{$server->charMapDatabase}.items";
+	$tempTable = new Flux_TemporaryTable($server->connection, $tableName, $fromTables);
+	
+	$col = "id AS item_id, name_japanese AS item_name, type";
+	$sql = "SELECT $col FROM $tableName WHERE items.id = ?";
+	$sth = $server->connection->getStatement($sql);
+
+	$sth->execute(array($shopItemID));
+	$originalItem = $sth->fetch();
+
+	if (count($_POST)) {
+		$tab    = $params->get('tab');
+		$price  = (int)$params->get('price');
+
+		if (!$price) {
+			$errorMessage = 'You must input a cash point cost greater than zero.';
+		} else {
+			if ($shop->edit($shopItemID, $tab, $price)) {
+				$session->setMessageData('Item has been successfully modified.');
+				$this->redirect($this->url('cashshop'));
+			} else {
+				$errorMessage = 'Failed to modify the item.';
+			}
+		}
+	}
+	
+	if (empty($tab)) {
+		$tab = $item->shop_item_tab;
+	}
+	if (empty($price)) {
+		$price = $item->shop_item_price;
+	}
+}
+
+?>

--- a/modules/cashshop/index.php
+++ b/modules/cashshop/index.php
@@ -1,0 +1,31 @@
+<?php
+if (!defined('FLUX_ROOT')) exit; 
+
+$this->loginRequired();
+
+if (!$auth->allowedToManageCashShop) {
+	$this->deny();
+}
+$title = 'CashShop';
+
+require_once 'Flux/TemporaryTable.php';
+
+$tabs = Flux::config('CashShopCategories')->toArray();
+
+if($server->isRenewal) {
+	$fromTables = array("{$server->charMapDatabase}.item_db_re", "{$server->charMapDatabase}.item_db2_re");
+} else {
+	$fromTables = array("{$server->charMapDatabase}.item_db", "{$server->charMapDatabase}.item_db2");
+}
+$tableName = "{$server->charMapDatabase}.items";
+$tempTable = new Flux_TemporaryTable($server->connection, $tableName, $fromTables);
+
+$col = "cash.tab AS tab, cash.item_id AS item_id, cash.price AS price, items.name_japanese AS item_name";
+$sql = "SELECT $col FROM {$server->charMapDatabase}.`item_cash_db` AS cash ";
+$sql.= "LEFT OUTER JOIN {$server->charMapDatabase}.items ON items.id = cash.item_id ORDER BY tab";
+$sth = $server->connection->getStatement($sql);
+
+$sth->execute();
+$items = $sth->fetchAll();
+
+?>

--- a/modules/item/pagemenu/view.php
+++ b/modules/item/pagemenu/view.php
@@ -14,5 +14,8 @@ if ($auth->actionAllowed('itemshop', 'add') && $auth->allowedToAddShopItem) {
 		$pageMenu['Add to Item Shop'] = $this->url('itemshop', 'add', array('id' => $item->item_id));
 	}
 }
+if ($auth->actionAllowed('cashshop', 'add') && $auth->allowedToManageCashShop) {
+	$pageMenu['Add to Cash Shop'] = $this->url('cashshop', 'add', array('id' => $item->item_id));
+}
 return $pageMenu;
 ?>

--- a/themes/default/cashshop/add.php
+++ b/themes/default/cashshop/add.php
@@ -1,0 +1,41 @@
+<?php if (!defined('FLUX_ROOT')) exit; ?>
+<h2>CashShop</h2>
+<h3>Add Item to the CashShop</h3>
+<?php if ($item): ?>
+<?php if (!empty($errorMessage)): ?>
+<p class="red"><?php echo htmlspecialchars($errorMessage) ?></p>
+<?php endif ?>
+<form action="<?php echo $this->urlWithQs ?>" method="post" enctype="multipart/form-data">
+<table class="vertical-table">
+	<tr>
+		<th>Item ID</th>
+		<td><?php echo $this->linkToItem($item->item_id, $item->item_id) ?></td>
+	</tr>
+	<tr>
+		<th>Name</th>
+		<td><?php echo htmlspecialchars($item->item_name) ?></td>
+	</tr>
+	<tr>
+		<th><label for="tab">In-Game Tab</label></th>
+		<td>
+			<select name="tab" id="tab">
+				<?php foreach ($categories as $categoryID => $cat): ?>
+					<option value="<?php echo (int)$categoryID ?>"<?php if ($category === (string)$categoryID) echo ' selected="selected"' ?>><?php echo htmlspecialchars($cat) ?></option>
+				<?php endforeach ?>
+			</select>
+		</td>
+	</tr>
+	<tr>
+		<th><label for="price">CashPoints Cost</label></th>
+		<td><input type="text" class="short" name="price" id="price" value="<?php echo htmlspecialchars($params->get('price')) ?>" /></td>
+	</tr>
+	<tr>
+		<td colspan="2" align="right">
+			<input type="submit" value="Add" />
+		</td>
+	</tr>
+</table>
+</form>
+<?php else: ?>
+<p>Cannot add an unknown item to the item shop. <a href="javascript:history.go(-1)">Go back</a>.</p>
+<?php endif ?>

--- a/themes/default/cashshop/delete.php
+++ b/themes/default/cashshop/delete.php
@@ -1,0 +1,3 @@
+<?php if (!defined('FLUX_ROOT')) exit; ?>
+<h2>CashShop</h2>
+<p>Failed to delete item. <a href="javascript:history.go(-1)">Go back</a>.</p>

--- a/themes/default/cashshop/edit.php
+++ b/themes/default/cashshop/edit.php
@@ -1,0 +1,41 @@
+<?php if (!defined('FLUX_ROOT')) exit; ?>
+<h2>CashShop</h2>
+<h3>Modify Item in the CashShop</h3>
+<?php if ($item): ?>
+<?php if (!empty($errorMessage)): ?>
+<p class="red"><?php echo htmlspecialchars($errorMessage) ?></p>
+<?php endif ?>
+<form action="<?php echo $this->urlWithQs ?>" method="post" enctype="multipart/form-data">
+<table class="vertical-table">
+	<tr>
+		<th>Item ID</th>
+		<td><?php echo $this->linkToItem($item->shop_item_id, $item->shop_item_id) ?></td>
+	</tr>
+	<tr>
+		<th>Name</th>
+		<td><?php echo htmlspecialchars($item->shop_item_name) ?></td>
+	</tr>
+	<tr>
+		<th><label for="tab">Tab</label></th>
+		<td>
+			<select name="tab" id="tab">
+				<?php foreach ($tabs as $categoryID => $cat): ?>
+					<option value="<?php echo (int)$categoryID ?>"<?php if ($tab === (string)$categoryID) echo ' selected="selected"' ?>><?php echo htmlspecialchars($cat) ?></option>
+				<?php endforeach ?>
+			</select>
+		</td>
+	</tr>
+	<tr>
+		<th><label for="price">Price</label></th>
+		<td><input type="text" class="short" name="price" id="price" value="<?php echo htmlspecialchars($price) ?>" /></td>
+	</tr>
+	<tr>
+		<td colspan="2" align="right">
+			<input type="submit" value="Modify" />
+		</td>
+	</tr>
+</table>
+</form>
+<?php else: ?>
+<p>Cannot modify an unknown item to the cashshop. <a href="javascript:history.go(-1)">Go back</a>.</p>
+<?php endif ?>

--- a/themes/default/cashshop/index.php
+++ b/themes/default/cashshop/index.php
@@ -1,0 +1,23 @@
+<?php if (!defined('FLUX_ROOT')) exit; ?>
+<h2>CashShop</h2>
+<?php if (!empty($errorMessage)): ?>
+<p class="red"><?php echo htmlspecialchars($errorMessage) ?></p>
+<?php endif ?>
+<table class="vertical-table">
+	<tr>
+		<th>Tab</th>
+		<th>Item ID</th>
+		<th>Item Name</th>
+		<th>Price</th>
+		<th>Options</th>
+	</tr>
+	<?php foreach($items as $item):?>
+	<tr>
+		<td><?php echo $tabs[$item->tab] ?></td>
+		<td><?php echo $this->linkToItem($item->item_id, $item->item_id) ?></td>
+		<td><?php echo $this->linkToItem($item->item_id, htmlspecialchars($item->item_name)) ?></td>
+		<td><?php echo $item->price ?></td>
+		<td><a href="<?php echo $this->url('cashshop', 'edit', array('id' => $item->item_id)) ?>">Edit</a> | <a href="<?php echo $this->url('cashshop', 'delete', array('id' => $item->item_id)) ?>">Remove</a></td>
+	</tr>	
+	<?php endforeach ?>
+</table>


### PR DESCRIPTION
* Provides admins the ability to manage the in-game CashShop via their website.
* Items can be added to the CashShop by viewing their ItemDB entry and clicking "Add to CashShop".
* Default Tab entries match rAthena's description. However, in-game textures may have text that differs to these names. Edit as you like.

Signed-off-by: Akkarinage <akkarin@rathena.org>