### PR TITLE
Fix style empty-row

### DIFF
--- a/themes/default/css/flux.css
+++ b/themes/default/css/flux.css
@@ -1015,7 +1015,7 @@ textarea {
 }
 
 .empty-row {
-	visibility: hidden;
+	display: none;
 }
 
 .item-drop-mvp td {


### PR DESCRIPTION
A small issue about the style of table list in `default` theme.
Height of table list include `empty-row`
![screen shot 2018-03-02 at 11 52 26 am](https://user-images.githubusercontent.com/9859310/36883962-49c4387e-1e10-11e8-8d55-16931e79f790.png)

The reason:
```css
 .empty-row {
    visibility: hidden;
 }
```
`visibility: hidden;` just hidden content of element but keep width, height and position.
I think we should be using `display: none;`
