### PR TITLE
Fix replace font tag for color highlight

### DIFF
--- a/modules/item/iteminfo.php
+++ b/modules/item/iteminfo.php
@@ -35,7 +35,16 @@ if($files->get('iteminfo')) {
                     }
                     break;
                 case (preg_match('/(.*?)(\")(.*?)(\^)([0-9a-fA-F]{6})(.*?)(\^0{6})(.*?)\"(,?)/', $array[$i]) ? true : false):
-                    $array[$i] = preg_replace('/(.*?)(\")(.*?)(\^)([0-9a-fA-F]{6})(.*?)(\^0{6})(.*?)\"(,?)/', '$3<font color="#$5">$6</font>$8<br />', $array[$i]);
+                    $colorExplode = explode("^000000", $array[$i]);
+                    $strDesc = '';
+                    foreach ($colorExplode as $index => $str) {
+                        $fontStr = preg_replace('/(.*?)(\^)([0-9a-fA-F]{6})(.*)/', '$1<font color="#$3">$4</font>', $str);
+                        $strDesc .= $fontStr;
+                    }
+                    
+                    // Trim space, double quote, comma
+                    $strDesc = trim(trim(trim($strDesc), '",'), '"') . '<br />';
+                    $array[$i] = $strDesc;
                 case (preg_match('/\s{2,}(\")(.*?)\"(,?)/', $array[$i]) ? true : false):
                     if($check == true){
                         $sqlp = preg_replace('/\s{2,}(\")(.*?)\"(,?)/', '$2<br />', $array[$i]);


### PR DESCRIPTION
My current solution for issue #166 
I explode string with `^000000` and replace color height to `HTML` font tag.
If you have any way easier, please suggest or open a pull request.
I already test and compare the results. You can check first 200 lines compare file [here](https://gist.github.com/vietlubu/a0250d620860cd81d0e792df9b5c7b68)
Result: Item ID 990
![screen shot 2018-03-08 at 11 04 29 am](https://user-images.githubusercontent.com/9859310/37132609-1a4bcb74-22c1-11e8-8aff-ac78d1cd0b9f.png)
