### PR TITLE
Moved card0 check to config & Flux lib

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -407,6 +407,13 @@ return array(
 		array('module' => 'guild', 'action' => 'emblem')
 	),
 
+	// Card0 special flag. Older rAthena the values are 254,255,-256
+	'ItemSpecial' => array(
+		'forge' => 0x00FF,
+		'create' => 0x00FE,
+		'pet' => 0x0100,
+	),
+
 	// Job classes, loaded from another file to avoid cluttering this one.
 	// There isn't normally a need to modify this file, unless it's been
 	// modified in an update. (In English: DON'T TOUCH THIS.)

--- a/lib/Flux.php
+++ b/lib/Flux.php
@@ -934,5 +934,19 @@ class Flux {
 		$size = Flux::config("MonsterSizes.$size");
 		return $size;
 	}
+	
+	/**
+	 * Check if item is special
+	 * @param $item Item object fetched from table
+	 * @return True if item's card0 is special, false otherwise
+	 */
+	public static function itemIsSpecial($item) {
+		$special = Flux::config('ItemSpecial');
+		if (!$special)
+			return false;
+		if ($item->card0 && ($item->card0 == $special->get('forge') || $item->card0 == $special->get('create') || $item->card0 == $special->get('pet')))
+			return true;
+		return false;
+	}
 }
 ?>

--- a/lib/Flux/Template.php
+++ b/lib/Flux/Template.php
@@ -166,6 +166,21 @@ class Flux_Template {
 	protected $urlWithQS; // compatibility.
 	
 	/**
+	 * CARD0_FORGE value for checking
+	 */
+	protected $itemIsForged;
+	
+	/**
+	 * CARD0_CREATE value for checking
+	 */
+	protected $itemIsCreation;
+	
+	/**
+	 * CARD0_PET value for checking
+	 */
+	protected $itemIsPetEgg;
+	
+	/**
 	 * Module/action for missing action's event.
 	 *
 	 * @access protected
@@ -227,6 +242,11 @@ class Flux_Template {
 		$this->missingActionModuleAction = $config->get('missingActionModuleAction', false);
 		$this->missingViewModuleAction   = $config->get('missingViewModuleAction', false);
 		$this->referer                   = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
+
+		$special = Flux::config('ItemSpecial');
+		$this->itemIsForged = $special->get('forge');
+		$this->itemIsCreation = $special->get('create');
+		$this->itemIsPetEgg = $special->get('pet');
 
 		// Read manifest file if exists
 		if (file_exists($this->themePath.'/'.$this->themeName.'/manifest.php')) {


### PR DESCRIPTION
* Fixed #190
* The card0 values are defined in config file (application.php) in `ItemSpecial`. By default, using rAthena's card0 values.
* The usage will be `Flux::itemIsSpecial($item)`. Returns `true` if item's card0 is special, `false` otherwise
* For control checking if item is forged, brew/`getnameditem`, or pet egg
  * `if ($item->card0 == $this->itemIsForged)`
  * `if ($item->card0 == $this->itemIsCreation)`
  * `if ($item->card0 == $this->itemIsPetEgg)`