### PR TITLE
update validate e-mail

### DIFF
--- a/lib/Flux/LoginServer.php
+++ b/lib/Flux/LoginServer.php
@@ -135,7 +135,7 @@ class Flux_LoginServer extends Flux_BaseServer {
 		elseif (Flux::config('PasswordMinSymbol') > 0 && preg_match_all('/[^A-Za-z0-9]/', $password, $matches) < Flux::config('PasswordMinSymbol')) {
 			throw new Flux_RegisterError('Passwords must contain at least ' + intval(Flux::config('PasswordMinSymbol')) + ' symbol(s)', Flux_RegisterError::PASSWORD_NEED_SYMBOL);
 		}
-		elseif (!preg_match('/^(.+?)@(.+?)$/', $email)) {
+		elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
 			throw new Flux_RegisterError('Invalid e-mail address', Flux_RegisterError::INVALID_EMAIL_ADDRESS);
 		}
 		elseif ($email!==$email2) {

--- a/modules/account/changemail.php
+++ b/modules/account/changemail.php
@@ -16,7 +16,7 @@ if (count($_POST)) {
 	elseif ($email == $session->account->email) {
 		$errorMessage = Flux::message('EmailCannotBeSame');
 	}
-	elseif (!preg_match('/^(.+?)@(.+?)$/', $email)) {
+	elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
 		$errorMessage = Flux::message('EmailInvalid');
 	}
 	elseif (!Flux::config('AllowDuplicateEmails')) {


### PR DESCRIPTION
It does not allow a player with an incomplete email to be registered.

Example:
name@name
test@test

Making validation more efficient.

Example:
name@name.com
name@gmail.com
name@name.online