### PR TITLE
Correct UTF-8 Support for the Mailer Function

### DIFF
--- a/lib/Flux/Mailer.php
+++ b/lib/Flux/Mailer.php
@@ -81,6 +81,7 @@ class Flux_Mailer {
 			}
 		}
 		$this->pm->isHTML(true);
+		$this->pm->CharSet = 'UTF-8';
 		$this->pm->AddAddress($recipient);
 		$this->pm->Subject = $subject;
 		$this->pm->msgHTML($content);


### PR DESCRIPTION
making the template for some languages like Arabic will mess up the encoding
this ensure that mails are sent with UTF-8
i don't know about this but it might be a good idea to add it to flux config.php ?