### PR TITLE
no discord message if 'RequireEmailConfirm' true

### DIFF
--- a/modules/account/create.php
+++ b/modules/account/create.php
@@ -63,11 +63,11 @@ if (count($_POST)) {
 				
 				if ($sent) {
 					$message  = Flux::message('AccountCreateEmailSent');
-					$discordMessage = 'Confirmation EMail has been sent.';
+					$discordMessage = 'Confirmation email has been sent.';
 				}
 				else {
 					$message  = Flux::message('AccountCreateFailed');
-					$discordMessage = 'Failed to send the Confirmation EMail.';
+					$discordMessage = 'Failed to send the Confirmation email.';
 				}
 				
 				$session->setMessageData($message);

--- a/modules/account/create.php
+++ b/modules/account/create.php
@@ -63,24 +63,26 @@ if (count($_POST)) {
 				
 				if ($sent) {
 					$message  = Flux::message('AccountCreateEmailSent');
+					$discordMessage = 'Confirmation EMail has been sent.';
 				}
 				else {
 					$message  = Flux::message('AccountCreateFailed');
+					$discordMessage = 'Failed to send the Confirmation EMail.';
 				}
 				
 				$session->setMessageData($message);
-				$this->redirect();
 			}
 			else {
 				$session->login($server->serverName, $username, $password, false);
 				$session->setMessageData(Flux::message('AccountCreated'));
-				if(Flux::config('DiscordUseWebhook')) {
-					if(Flux::config('DiscordSendOnRegister')) {
-						sendtodiscord(Flux::config('DiscordWebhookURL'), 'New User registration: '. $username);
-					}
-				}
-				$this->redirect();
+				$discordMessage = 'Account Created.';
 			}
+			if(Flux::config('DiscordUseWebhook')) {
+				if(Flux::config('DiscordSendOnRegister')) {
+					sendtodiscord(Flux::config('DiscordWebhookURL'), 'New User registration: "'. $username . '" , ' . $discordMessage);
+				}
+			}
+			$this->redirect();
 		}
 		else {
 			exit('Uh oh, what happened?');


### PR DESCRIPTION
now discord webhook will send message even if `RequireEmailConfirm = true`
and add more information so we would know if there is a problem or not when someone register
