### PR TITLE
Added bindParams function

### DIFF
--- a/lib/Flux/Connection/Statement.php
+++ b/lib/Flux/Connection/Statement.php
@@ -4,20 +4,59 @@ require_once 'Flux/Error.php';
 
 class Flux_Connection_Statement {
 	public $stmt;
+	private $bind_param = false;
 	private static $errorLog;
-	
+
 	public function __construct(PDOStatement $stmt)
 	{
 		$this->stmt = $stmt;
-		
+
 		if (!self::$errorLog) {
 			self::$errorLog = new Flux_LogFile(FLUX_DATA_DIR.'/logs/mysql/errors/'.date('Ymd').'.log', 'a');
 		}
 	}
-	
-	public function execute(array $inputParameters = array())
+
+    /*
+    * Quick PDOStatement::bindParam for array parameter
+    * Array parameter must be
+    * $array[':paramater'] = [ variable, PDO::PARAM_* constants ];
+    */
+    public function bindParams(array $params)
+    {
+        foreach ($params as $key => $param) {
+            $this->stmt->bindParam($key, $param[0], $param[1]);
+        }
+
+        $this->bind_param = true;
+    }
+
+	public function execute(array $inputParameters = array(), $bind_param = false)
 	{
-		$res = $this->stmt->execute($inputParameters);
+		if ($this->bind_param) {
+			$res = $this->stmt->execute();
+		} elseif ($bind_param) {
+			foreach ($inputParameters as $i => &$param) {
+				switch (true) {
+					case is_bool($param):
+						$type = PDO::PARAM_BOOL;
+						break;
+					case is_int($param):
+						$type = PDO::PARAM_INT;
+						break;
+					case is_null($param):
+						$type = PDO::PARAM_NULL;
+						break;
+					default:
+						$type = PDO::PARAM_STR;
+						break;
+				}
+				$this->stmt->bindParam($i+1, $param, $type);
+			}
+			$res = $this->stmt->execute();
+		} else {
+			$res = $this->stmt->execute($inputParameters);
+		}
+
 		Flux::$numberOfQueries++;
 		if ((int)$this->stmt->errorCode()) {
 			$info = $this->stmt->errorInfo();
@@ -29,10 +68,9 @@ class Flux_Connection_Statement {
 		}
 		return $res;
 	}
-	
+
 	public function __call($method, $args)
 	{
 		return call_user_func_array(array($this->stmt, $method), $args);
 	}
 }
-?>

--- a/modules/logdata/login.php
+++ b/modules/logdata/login.php
@@ -45,8 +45,7 @@ if ($response) {
 
 $sql = "SELECT COUNT(time) AS total FROM {$server->logsDatabase}.loginlog WHERE 1=1 $sqlpartial";
 $sth = $server->connection->getStatementForLogs($sql);
-$sth->bindParams($bind);
-$sth->execute();
+$sth->execute($bind, true);
 
 $paginator = $this->getPaginator($sth->fetch()->total);
 $paginator->setSortableColumns(array(
@@ -56,8 +55,7 @@ $paginator->setSortableColumns(array(
 $sql = "SELECT time, ip, user, rcode, log FROM {$server->logsDatabase}.loginlog WHERE 1=1 $sqlpartial";
 $sql = $paginator->getSQL($sql);
 $sth = $server->connection->getStatementForLogs($sql);
-$sth->bindParams($bind);
-$sth->execute();
+$sth->execute($bind, true);
 
 $logins = $sth->fetchAll();
 

--- a/modules/logdata/login.php
+++ b/modules/logdata/login.php
@@ -14,38 +14,39 @@ $logMessage = trim($params->get('log'));
 $response   = trim($params->get('rcode'));
 
 if ($dateAfter) {
-	$sqlpartial .= 'AND time >= ? ';
-	$bind[]      = $dateAfter;
+	$sqlpartial .= 'AND time >= :dateAfter ';
+	$bind[':dateAfter'] = [ $dateAfter, PDO::PARAM_STR ];
 }
 
 if ($dateBefore) {
-	$sqlpartial .= 'AND time <= ? ';
-	$bind[]      = $dateBefore;
+	$sqlpartial .= 'AND time <= :dateBefore ';
+	$bind[':dateBefore'] = [ $dateBefore, PDO::PARAM_STR ];
 }
 
 if ($ipAddress) {
-	$sqlpartial .= 'AND ip LIKE ? ';
-	$bind[]      = "%$ipAddress%";
+	$sqlpartial .= 'AND ip LIKE :ipAddress ';
+	$bind[':ipAddress'] = [ "%$ipAddress%", PDO::PARAM_STR ];
 }
 
 if ($username) {
-	$sqlpartial .= 'AND user LIKE ? ';
-	$bind[]      = "%$username%";
+	$sqlpartial .= 'AND user LIKE :username ';
+	$bind[':username'] = [ "%$username%", PDO::PARAM_STR ];
 }
 
 if ($logMessage) {
-	$sqlpartial .= 'AND log LIKE ? ';
-	$bind[]      = "%$logMessage%";
+	$sqlpartial .= 'AND log LIKE :logmes ';
+	$bind[':logmes'] = [ "%$logMessage%", PDO::PARAM_STR ];
 }
 
 if ($response) {
-	$sqlpartial .= 'AND response = ? ';
-	$bind[]      = $response;
+	$sqlpartial .= 'AND rcode = :rcode ';
+	$bind[':rcode'] = [ $response, PDO::PARAM_INT ];
 }
 
 $sql = "SELECT COUNT(time) AS total FROM {$server->logsDatabase}.loginlog WHERE 1=1 $sqlpartial";
 $sth = $server->connection->getStatementForLogs($sql);
-$sth->execute($bind);
+$sth->bindParams($bind);
+$sth->execute();
 
 $paginator = $this->getPaginator($sth->fetch()->total);
 $paginator->setSortableColumns(array(
@@ -55,7 +56,8 @@ $paginator->setSortableColumns(array(
 $sql = "SELECT time, ip, user, rcode, log FROM {$server->logsDatabase}.loginlog WHERE 1=1 $sqlpartial";
 $sql = $paginator->getSQL($sql);
 $sth = $server->connection->getStatementForLogs($sql);
-$sth->execute($bind);
+$sth->bindParams($bind);
+$sth->execute();
 
 $logins = $sth->fetchAll();
 
@@ -65,13 +67,13 @@ if ($logins) {
 	foreach ($logins as $_tmplogin) {
 		$usernames[] = $noCase ? strtolower($_tmplogin->user) : $_tmplogin->user;
 	}
-	
+
 	$uid  = $noCase ? 'LOWER(userid)' : 'userid';
 	$sql  = "SELECT $uid AS userid, account_id FROM {$server->loginDatabase}.login WHERE ";
 	$sql .= "sex != 'S' AND group_id >= 0 AND $uid IN (".implode(',', array_fill(0, count($usernames), '?')).")";
 	$sth  = $server->connection->getStatement($sql);
-	$sth->execute($usernames);
-	
+	$sth->execute($usernames, true);
+
 	$data = $sth->fetchAll();
 	if ($data) {
 		$accounts = array();
@@ -79,7 +81,7 @@ if ($logins) {
 			$userid = $noCase ? strtolower($row->userid) : $row->userid;
 			$accounts[$userid] = $row->account_id;
 		}
-		
+
 		foreach ($logins as $_tmplogin) {
 			$userid = $noCase ? strtolower($_tmplogin->user) : $_tmplogin->user;
 			if (array_key_exists($userid, $accounts)) {
@@ -88,4 +90,3 @@ if ($logins) {
 		}
 	}
 }
-?>


### PR DESCRIPTION
* A quick bulk bindParam for query params
* Added 2nd param in execute function to set auto-bindParam
* Example usage in logdata/login also fix `response` is invalid column, must be `rcode`


because fluxcp codes always set the params before doing prepare statement `$server->connection->getStatement`