### PR TITLE
correct auth validation

### DIFF
--- a/lib/Flux/LoginServer.php
+++ b/lib/Flux/LoginServer.php
@@ -66,14 +66,15 @@ class Flux_LoginServer extends Flux_BaseServer {
 	 */
 	public function isAuth($username, $password)
 	{
-		if ($this->config->get('UseMD5')) {
-			$password = Flux::hashPassword($password);
-		}
 		
 		if (trim($username) == '' || trim($password) == '') {
 			return false;
 		}
-		
+
+     	if ($this->config->get('UseMD5')) {
+			$password = Flux::hashPassword($password);
+		}
+        
 		$sql  = "SELECT userid FROM {$this->loginDatabase}.login WHERE sex != 'S' AND group_id >= 0 ";
 		if ($this->config->getNoCase()) {
 			$sql .= 'AND LOWER(userid) = LOWER(?) ';


### PR DESCRIPTION
When md5 is active, the " trim($ password) == '' " condition is no longer valid, because even if the password is blank a 32 character code is generated.