### PR TITLE
Option to prevent registration spam

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -55,6 +55,7 @@ return array(
 	'RequireEmailConfirm'		=> false,					// Require e-mail confirmation during registration.
 	'RequireChangeConfirm'		=> false,					// Require confirmation when changing e-mail addresses.
 	'EmailConfirmExpire'		=> 48,						// E-mail confirmations expire hours. Unconfirmed accounts will expire after this period of time.
+	'AntiRegesterationSpam'		=> false,					// Work only when 'RequireEmailConfirm' is active , if the ip have an unconfirmed account , it would privent the user from registering new account.
 	'PincodeEnabled'		=> true,					// Whether or not the pincode system is enabled in your server. (Check your char_athena.conf file. Enabled by default.)
 	'MailerFromAddress'			=> 'noreply@localhost',		// The e-mail address displayed in the From field.
 	'MailerFromName'			=> 'MailerName',			// The name displayed with the From e-mail address.

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -210,6 +210,7 @@ return array(
 	'InvalidSecurityCode'     => 'Please enter the security code correctly.',
 	'InvalidPassword'         => 'Your password contains invalid characters.',
 	'InvalidBirthdate'        => 'Invalid birthdate input.',
+	'AntiRegesterationSpam'   => 'Anti Registeration Spam System is Active , Contact the Admin to Complete your registeration.',
 	'CriticalRegisterError'   => 'Something bad happened.  Report to an administrator ASAP.',
 	// - account/edit
 	'AccountEditTitle'        => 'Modify Account',

--- a/lib/Flux/RegisterError.php
+++ b/lib/Flux/RegisterError.php
@@ -23,5 +23,6 @@ class Flux_RegisterError extends Flux_Error {
 	const INVALID_PASSWORD       = 18;
 	const INVALID_BIRTHDATE      = 19;
 	const INVALID_EMAIL_CONF     = 20;
+	const ANTI_REGESTERATION_SPAM= 21;
 }
 ?>

--- a/modules/account/create.php
+++ b/modules/account/create.php
@@ -150,6 +150,9 @@ if (count($_POST)) {
 			case Flux_RegisterError::INVALID_BIRTHDATE:
 				$errorMessage = Flux::message('InvalidBirthdate');
 				break;
+			case Flux_RegisterError::ANTI_REGESTERATION_SPAM:
+				$errorMessage = Flux::message('AntiRegesterationSpam');
+				break;
 			default:
 				$errorMessage = Flux::message('CriticalRegisterError');
 				break;


### PR DESCRIPTION
require `RequireEmailConfirm = true`
so the idea is
if the user register an account and did not activated it using his email
he can't register a new account until he activate the old account
ofc this would mean the admin needs to keep his eyes on if a confirmation email didn't deliver , however this would work well if the admin has setup his site well

TODO: fix English and Grammar xD