### PR TITLE
Add Divine-Pride integration (items and monster images)

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -18,6 +18,7 @@ return array(
 	'ItemImageNameFormat'		=> '%d.png',				// The filename format for item images (defaults to {itemid}.png).
 	'MonsterImageNameFormat'	=> '%d.gif',				// The filename format for monster images (defaults to {monsterid}.gif).
 	'JobImageNameFormat'		=> '%d.gif',				// The filename format for job images (defaults to {jobid}.gif).
+	'DivinePrideIntegration'	=> true,					// Dowload monsters and items images from https://www.divine-pride.net if it's not exist.
 	'ForceEmptyEmblem'			=> false,					// Forcefully display empty guild emblems, helpful when you don't have GD2 installed.
 	'EmblemCacheInterval'		=> 12,						// Hourly interval to re-cache guild emblems (set to 0 to disable emblem cache).
 	'SessionCookieExpire'		=> 48,						// Duration in hours.

--- a/lib/Flux/Template.php
+++ b/lib/Flux/Template.php
@@ -1372,7 +1372,15 @@ class Flux_Template {
 	{
 		$path = sprintf(FLUX_DATA_DIR."/items/icons/".Flux::config('ItemIconNameFormat'), $itemID);
 		$link = preg_replace('&/{2,}&', '/', "{$this->basePath}/$path");
-		return file_exists($path) ? $link : false;
+		
+		if(Flux::config('DivinePrideIntegration') && !file_exists($path)) {
+			$download_link = "https://static.divine-pride.net/images/items/item/$itemID.png";
+			$data = get_headers($download_link, true);
+			$size = isset($data['Content-Length']) ? (int)$data['Content-Length'] : 0;
+			if($size != 0 && $size != 654)
+				file_put_contents(sprintf(FLUX_DATA_DIR."/items/icons/".Flux::config('ItemIconNameFormat'), $itemID), file_get_contents($download_link));
+		}
+        return file_exists($path) ? $link : false;
 	}
 	
 	/**
@@ -1382,7 +1390,15 @@ class Flux_Template {
 	{
 		$path = sprintf(FLUX_DATA_DIR."/items/images/".Flux::config('ItemImageNameFormat'), $itemID);
 		$link = preg_replace('&/{2,}&', '/', "{$this->basePath}/$path");
-		return file_exists($path) ? $link : false;
+		
+		if(Flux::config('DivinePrideIntegration') && !file_exists($path)) {
+			$download_link = "https://static.divine-pride.net/images/items/collection/$itemID.png";
+			$data = get_headers($download_link, true);
+			$size = isset($data['Content-Length']) ? (int)$data['Content-Length'] : 0;
+			if($size != 0 && $size != 654)
+				file_put_contents(sprintf(FLUX_DATA_DIR."/items/images/".Flux::config('ItemImageNameFormat'), $itemID), file_get_contents($download_link));
+		}
+        return file_exists($path) ? $link : false;
 	}
 
  	/**
@@ -1392,7 +1408,15 @@ class Flux_Template {
 	{
 		$path = sprintf(FLUX_DATA_DIR."/monsters/".Flux::config('MonsterImageNameFormat'), $monsterID);
 		$link = preg_replace('&/{2,}&', '/', "{$this->basePath}/$path");
-		return file_exists($path) ? $link : false;
+		
+		if(Flux::config('DivinePrideIntegration') && !file_exists($path)) {
+			$download_link = "https://static.divine-pride.net/images/mobs/png/$monsterID.png";
+			$data = get_headers($download_link, true);
+			$size = isset($data['Content-Length']) ? (int)$data['Content-Length'] : 0;
+			if($size != 0 && $size != 654)
+				file_put_contents(sprintf(FLUX_DATA_DIR."/monsters/".Flux::config('MonsterImageNameFormat'), $monsterID), file_get_contents($download_link));
+		}
+        return file_exists($path) ? $link : false;
 	}
 	
 	/**

--- a/lib/Flux/Template.php
+++ b/lib/Flux/Template.php
@@ -1377,7 +1377,7 @@ class Flux_Template {
 			$download_link = "https://static.divine-pride.net/images/items/item/$itemID.png";
 			$data = get_headers($download_link, true);
 			$size = isset($data['Content-Length']) ? (int)$data['Content-Length'] : 0;
-			if($size != 0 && $size != 654)
+			if($size != 0)
 				file_put_contents(sprintf(FLUX_DATA_DIR."/items/icons/".Flux::config('ItemIconNameFormat'), $itemID), file_get_contents($download_link));
 		}
         return file_exists($path) ? $link : false;
@@ -1395,7 +1395,7 @@ class Flux_Template {
 			$download_link = "https://static.divine-pride.net/images/items/collection/$itemID.png";
 			$data = get_headers($download_link, true);
 			$size = isset($data['Content-Length']) ? (int)$data['Content-Length'] : 0;
-			if($size != 0 && $size != 654)
+			if($size != 0)
 				file_put_contents(sprintf(FLUX_DATA_DIR."/items/images/".Flux::config('ItemImageNameFormat'), $itemID), file_get_contents($download_link));
 		}
         return file_exists($path) ? $link : false;
@@ -1413,7 +1413,7 @@ class Flux_Template {
 			$download_link = "https://static.divine-pride.net/images/mobs/png/$monsterID.png";
 			$data = get_headers($download_link, true);
 			$size = isset($data['Content-Length']) ? (int)$data['Content-Length'] : 0;
-			if($size != 0 && $size != 654)
+			if($size != 0)
 				file_put_contents(sprintf(FLUX_DATA_DIR."/monsters/".Flux::config('MonsterImageNameFormat'), $monsterID), file_get_contents($download_link));
 		}
         return file_exists($path) ? $link : false;


### PR DESCRIPTION
This update dowload monsters and items images from https://www.divine-pride.net if it's not exist.
![image](https://user-images.githubusercontent.com/16213511/117842431-98920400-b286-11eb-8983-df4fe13ee90c.png)