### PR TITLE
PHP 7.4 compatibility update

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,10 +6,6 @@ if (version_compare(PHP_VERSION, '5.2.1', '<')) {
 	exit;
 }
 
-// Disable Zend Engine 1 compatibility mode.
-// See: http://www.php.net/manual/en/ini.core.php#ini.zend.ze1-compatibility-mode
-ini_set('zend.ze1_compatibility_mode', 0);
-
 // Time started.
 define('__START__', microtime(true));
 


### PR DESCRIPTION
Removed the short-lived zend.ze1_compatibility_mode directive.
Has been introduced in PHP 5.0.0, deprecated since PHP 5.3.0

Follow-up to 48caeccbc7a5205425e8b98ed592a2f174eb0dc6
