### PR TITLE
Added check for paypal notify by ip range

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -104,6 +104,21 @@ return array(
 		//'admin3@localhost'								// -- because your Business Email is also checked.
 	),
 	'PaypalHackNotify'          => true,                    // Send email notification if hack attempt detected (Notification will be send for each address in list PayPalBusinessEmail and PayPalReceiverEmails)
+	'PayPalAllowedHosts'        => array(					// PayPal IP list https://www.paypal.com/fm/smarthelp/article/what-are-the-ip-addresses-for-live-paypal-servers-ts1056
+		'ipn.sandbox.paypal.com',
+		'notify.paypal.com',
+		'66.211.170.66',
+		'173.0.81.1',
+		'173.0.81.0/24',
+		'173.0.81.33',
+		'173.0.81.65',
+		'173.0.81.140',
+		'64.4.240.0/21',
+		'64.4.248.0/22',
+		'6.211.168.0/22',
+		'173.0.80.0/20',
+		'91.243.72.0/23'
+	),
 	'GStorageLeaderOnly'		=> false,					// Only allow guild leader to view guild storage rather than all members?
 	'DivorceKeepChild'			=> false,					// Keep child after divorce?
 	'DivorceKeepRings'			=> false,					// Keep wedding rings after divorce?


### PR DESCRIPTION
Sometimes paypal sends notification from an IP address and checks failed, for example:
**[2022-02-20 16:19:20] Received notification from 173.0.81.140 (173.0.81.140)
[2022-02-21 18:42:20] Received notification from 173.0.81.140 (173.0.81.140)** 
[2022-02-20 02:22:03] Received notification from IP (notify.paypal.com)

Not all ip from list return 'notify.paypal.com' by gethostbyaddr function.
This fix should solve the problem.

Ip list from: https://www.paypal.com/fm/smarthelp/article/what-are-the-ip-addresses-for-live-paypal-servers-ts1056

Thanks ScarrBoy, charlieluvsu, Mirage, kianzack, Loki - Badarosk0 and Cookie for reports.