### PR TITLE
Fix some deprecated uses of htmlspecialchars for php8.1

### DIFF
--- a/lib/Flux.php
+++ b/lib/Flux.php
@@ -681,6 +681,9 @@ class Flux {
 	 */
 	public static function getItemType($id1)
 	{
+		if (is_null($id1))
+			return false;
+
 		$type = self::config("ItemTypes")->toArray();
 
 		if ($type[strtolower($id1)] != NULL) {

--- a/lib/Flux/Config.php
+++ b/lib/Flux/Config.php
@@ -94,6 +94,9 @@ class Flux_Config {
 	 */
 	public function get($key, $configObjectIfArray = true)
 	{
+		if (!is_string($key) || empty($key)) {
+			return null;
+		}
 		$keys = explode('.', $key);
 		$base = &$this->configArr;
 		$size = count($keys) - 1;

--- a/lib/Flux/Template.php
+++ b/lib/Flux/Template.php
@@ -643,7 +643,7 @@ class Flux_Template {
 		if (count($params)) {
 			$queryString .= Flux::config('UseCleanUrls') ? '?' : '&';
 			foreach ($params as $param => $value) {
-				$queryString .= sprintf('%s=%s&', $param, urlencode($value));
+				$queryString .= sprintf('%s=%s&', $param, urlencode($value ?: ''));
 			}
 			$queryString = rtrim($queryString, '&');
 		}

--- a/modules/cplog/login.php
+++ b/modules/cplog/login.php
@@ -9,8 +9,8 @@ $bind          = array();
 
 $password    = $params->get('password');
 $accountID   = (int)$params->get('account_id');
-$username    = trim($params->get('username'));
-$ipAddress   = trim($params->get('ip'));
+$username    = trim($params->get('username') ?: '');
+$ipAddress   = trim($params->get('ip') ?: '');
 $loginAfter  = $params->get('login_after_date');
 $loginBefore = $params->get('login_before_date');
 $errorCode   = $params->get('error_code');

--- a/modules/item/index.php
+++ b/modules/item/index.php
@@ -102,7 +102,7 @@ try {
 			}
 		}
 
-		if ($equipLoc !== false && $equipLoc !== '-1') {
+		if ($equipLoc !== false && !is_null($equipLoc) && $equipLoc !== '-1') {
 			$equipLocs = explode('/', $equipLoc);
 
 			if($equipLoc && count($equipLocs) == 1) {

--- a/modules/mail/index.php
+++ b/modules/mail/index.php
@@ -2,9 +2,9 @@
 if (!defined('FLUX_ROOT')) exit;
 $this->loginRequired();
 $title = Flux::message('MailerTitle');
-$whoto = trim($params->get('whoto'));
-$template = trim($params->get('template'));
-$subject = trim($params->get('subject'));
+$whoto = trim($params->get('whoto') ?: '');
+$template = trim($params->get('template') ?: '');
+$subject = trim($params->get('subject') ?: '');
 $selectedtemplate = $template.'.php';
 
 

--- a/modules/monster/index.php
+++ b/modules/monster/index.php
@@ -30,7 +30,7 @@ try {
 		$size           = $params->get('size');
 		$race           = $params->get('race');
 		$element        = $params->get('element');
-		$mvp            = strtolower($params->get('mvp'));
+		$mvp            = strtolower($params->get('mvp') ?: '');
 		$custom         = $params->get('custom');
 		
 		if ($monsterName) {

--- a/modules/ranking/character.php
+++ b/modules/ranking/character.php
@@ -6,7 +6,7 @@ $classes  = Flux::config('JobClasses')->toArray();
 $jobClass = $params->get('jobclass');
 $bind     = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?: '') === '') {
 	$jobClass = null;
 }
 

--- a/themes/default/account/create.php
+++ b/themes/default/account/create.php
@@ -43,7 +43,7 @@
 
 		<tr>
 			<th><label for="register_username"><?php echo htmlspecialchars(Flux::message('AccountUsernameLabel')) ?></label></th>
-			<td><input type="text" name="username" id="register_username" value="<?php echo htmlspecialchars($params->get('username')) ?>" /></td>
+			<td><input type="text" name="username" id="register_username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" /></td>
 		</tr>
 
 		<tr>
@@ -58,12 +58,12 @@
 
 		<tr>
 			<th><label for="register_email_address"><?php echo htmlspecialchars(Flux::message('AccountEmailLabel')) ?></label></th>
-			<td><input type="text" name="email_address" id="register_email_address" value="<?php echo htmlspecialchars($params->get('email_address')) ?>" /></td>
+			<td><input type="text" name="email_address" id="register_email_address" value="<?php echo htmlspecialchars($params->get('email_address') ?: '') ?>" /></td>
 		</tr>
 
 		<tr>
 			<th><label for="register_email_address"><?php echo htmlspecialchars(Flux::message('AccountEmailLabel2')) ?></label></th>
-			<td><input type="text" name="email_address2" id="register_email_address2" value="<?php echo htmlspecialchars($params->get('email_address2')) ?>" /></td>
+			<td><input type="text" name="email_address2" id="register_email_address2" value="<?php echo htmlspecialchars($params->get('email_address2') ?: '') ?>" /></td>
 		</tr>
 
 		<tr>

--- a/themes/default/account/index.php
+++ b/themes/default/account/index.php
@@ -5,21 +5,21 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="account_id"><?php echo htmlspecialchars(Flux::message('AccountIdLabel')) ?>:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?: '') ?>" />
 		...
 		<label for="username"><?php echo htmlspecialchars(Flux::message('UsernameLabel')) ?>:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" />
 		<?php if ($searchPassword): ?>
 		...
 		<label for="password"><?php echo htmlspecialchars(Flux::message('PasswordLabel')) ?>:</label>
-		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password')) ?>" />
+		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password') ?: '') ?>" />
 		<?php endif ?>
 		...
 		<label for="email"><?php echo htmlspecialchars(Flux::message('EmailAddressLabel')) ?>:</label>
-		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email')) ?>" />
+		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email') ?: '') ?>" />
 		...
 		<label for="last_ip"><?php echo htmlspecialchars(Flux::message('LastUsedIpLabel')) ?>:</label>
-		<input type="text" name="last_ip" id="last_ip" value="<?php echo htmlspecialchars($params->get('last_ip')) ?>" />
+		<input type="text" name="last_ip" id="last_ip" value="<?php echo htmlspecialchars($params->get('last_ip') ?: '') ?>" />
 		...
 		<label for="gender"><?php echo htmlspecialchars(Flux::message('GenderLabel')) ?>:</label>
 		<select name="gender" id="gender">
@@ -44,7 +44,7 @@
 			<option value="gt"<?php if ($account_group_id_op == 'gt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsGreaterThanLabel')) ?></option>
 			<option value="lt"<?php if ($account_group_id_op == 'lt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsLessThanLabel')) ?></option>
 		</select>
-		<input type="text" name="account_group_id" id="account_group_id" value="<?php echo htmlspecialchars($params->get('account_group_id')) ?>" />
+		<input type="text" name="account_group_id" id="account_group_id" value="<?php echo htmlspecialchars($params->get('account_group_id') ?: '') ?>" />
 		...
 		<label for="balance"><?php echo htmlspecialchars(Flux::message('CreditBalanceLabel')) ?>:</label>
 		<select name="balance_op">
@@ -52,7 +52,7 @@
 			<option value="gt"<?php if ($balance_op == 'gt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsGreaterThanLabel')) ?></option>
 			<option value="lt"<?php if ($balance_op == 'lt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsLessThanLabel')) ?></option>
 		</select>
-		<input type="text" name="balance" id="balance" value="<?php echo htmlspecialchars($params->get('balance')) ?>" />
+		<input type="text" name="balance" id="balance" value="<?php echo htmlspecialchars($params->get('balance') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="logincount"><?php echo htmlspecialchars(Flux::message('LoginCountLabel')) ?>:</label>
@@ -61,7 +61,7 @@
 			<option value="gt"<?php if ($logincount_op == 'gt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsGreaterThanLabel')) ?></option>
 			<option value="lt"<?php if ($logincount_op == 'lt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsLessThanLabel')) ?></option>
 		</select>
-		<input type="text" name="logincount" id="logincount" value="<?php echo htmlspecialchars($params->get('logincount')) ?>" />
+		<input type="text" name="logincount" id="logincount" value="<?php echo htmlspecialchars($params->get('logincount') ?: '') ?>" />
 		...
 		<label for="use_birthdate_after"><?php echo htmlspecialchars(Flux::message('BirthdateBetweenLabel')) ?>:</label>
 		<input type="checkbox" name="use_birthdate_after" id="use_birthdate_after"<?php if ($params->get('use_birthdate_after')) echo ' checked="checked"' ?> />

--- a/themes/default/account/login.php
+++ b/themes/default/account/login.php
@@ -16,7 +16,7 @@
 	<table class="generic-form-table">
 		<tr>
 			<th><label for="login_username"><?php echo htmlspecialchars(Flux::message('AccountUsernameLabel')) ?></label></th>
-			<td><input type="text" name="username" id="login_username" value="<?php echo htmlspecialchars($params->get('username')) ?>" /></td>
+			<td><input type="text" name="username" id="login_username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" /></td>
 		</tr>
 		<tr>
 			<th><label for="login_password"><?php echo htmlspecialchars(Flux::message('AccountPasswordLabel')) ?></label></th>

--- a/themes/default/account/transfer.php
+++ b/themes/default/account/transfer.php
@@ -13,12 +13,12 @@
 	<table class="generic-form-table">
 		<tr>
 			<th><label for="credits"><?php echo htmlspecialchars(Flux::message('TransferAmountLabel')) ?></label></th>
-			<td><input type="text" name="credits" id="credits" value="<?php echo htmlspecialchars($params->get('credits')) ?>" /></td>
+			<td><input type="text" name="credits" id="credits" value="<?php echo htmlspecialchars($params->get('credits') ?: '') ?>" /></td>
 			<td><p><?php echo htmlspecialchars(Flux::message('TransferAmountInfo')) ?></p></td>
 		</tr>
 		<tr>
 			<th><label for="char_name"><?php echo htmlspecialchars(Flux::message('TransferCharNameLabel')) ?></label></th>
-			<td><input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name')) ?>" /></td>
+			<td><input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name') ?: '') ?>" /></td>
 			<td><p><?php echo htmlspecialchars(Flux::message('TransferCharNameInfo')) ?></p></td>
 		</tr>
 		<tr>

--- a/themes/default/cashshop/add.php
+++ b/themes/default/cashshop/add.php
@@ -27,7 +27,7 @@
 	</tr>
 	<tr>
 		<th><label for="price">CashPoints Cost</label></th>
-		<td><input type="text" class="short" name="price" id="price" value="<?php echo htmlspecialchars($params->get('price')) ?>" /></td>
+		<td><input type="text" class="short" name="price" id="price" value="<?php echo htmlspecialchars($params->get('price') ?: '') ?>" /></td>
 	</tr>
 	<tr>
 		<td colspan="2" align="right">

--- a/themes/default/character/index.php
+++ b/themes/default/character/index.php
@@ -5,16 +5,16 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="char_id">Character ID:</label>
-		<input type="text" name="char_id" id="char_id" value="<?php echo htmlspecialchars($params->get('char_id')) ?>" />
+		<input type="text" name="char_id" id="char_id" value="<?php echo htmlspecialchars($params->get('char_id') ?: '') ?>" />
 		...
 		<label for="account">Account:</label>
-		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account')) ?>" />
+		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account') ?: '') ?>" />
 		...
 		<label for="char_name">Character:</label>
-		<input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name')) ?>" />
+		<input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name') ?: '') ?>" />
 		...
 		<label for="char_class">Job Class:</label>
-		<input type="text" name="char_class" id="char_class" value="<?php echo htmlspecialchars($params->get('char_class')) ?>" />
+		<input type="text" name="char_class" id="char_class" value="<?php echo htmlspecialchars($params->get('char_class') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="base_level">Base Level:</label>
@@ -23,7 +23,7 @@
 			<option value="gt"<?php if ($base_level_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($base_level_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="base_level" id="base_level" value="<?php echo htmlspecialchars($params->get('base_level')) ?>" />
+		<input type="text" name="base_level" id="base_level" value="<?php echo htmlspecialchars($params->get('base_level') ?: '') ?>" />
 		...
 		<label for="job_level">Job Level:</label>
 		<select name="job_level_op">
@@ -31,7 +31,7 @@
 			<option value="gt"<?php if ($job_level_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($job_level_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="job_level" id="job_level" value="<?php echo htmlspecialchars($params->get('job_level')) ?>" />
+		<input type="text" name="job_level" id="job_level" value="<?php echo htmlspecialchars($params->get('job_level') ?: '') ?>" />
 		...
 		<label for="zeny">Zeny:</label>
 		<select name="zeny_op">
@@ -39,23 +39,23 @@
 			<option value="gt"<?php if ($zeny_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($zeny_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="zeny" id="zeny" value="<?php echo htmlspecialchars($params->get('zeny')) ?>" />
+		<input type="text" name="zeny" id="zeny" value="<?php echo htmlspecialchars($params->get('zeny') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="guild">Guild:</label>
-		<input type="text" name="guild" id="guild" value="<?php echo htmlspecialchars($params->get('guild')) ?>" />
+		<input type="text" name="guild" id="guild" value="<?php echo htmlspecialchars($params->get('guild') ?: '') ?>" />
 		...
 		<label for="partner">Partner:</label>
-		<input type="text" name="partner" id="partner" value="<?php echo htmlspecialchars($params->get('partner')) ?>" />
+		<input type="text" name="partner" id="partner" value="<?php echo htmlspecialchars($params->get('partner') ?: '') ?>" />
 		...
 		<label for="mother">Mother:</label>
-		<input type="text" name="mother" id="mother" value="<?php echo htmlspecialchars($params->get('mother')) ?>" />
+		<input type="text" name="mother" id="mother" value="<?php echo htmlspecialchars($params->get('mother') ?: '') ?>" />
 		...
 		<label for="father">Father:</label>
-		<input type="text" name="father" id="father" value="<?php echo htmlspecialchars($params->get('father')) ?>" />
+		<input type="text" name="father" id="father" value="<?php echo htmlspecialchars($params->get('father') ?: '') ?>" />
 		...
 		<label for="child">Child:</label>
-		<input type="text" name="child" id="child" value="<?php echo htmlspecialchars($params->get('child')) ?>" />
+		<input type="text" name="child" id="child" value="<?php echo htmlspecialchars($params->get('child') ?: '') ?>" />
 	</p>
 	<p>	
 		<label for="online">Online Status:</label>
@@ -71,7 +71,7 @@
 			<option value="gt"<?php if ($slot_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($slot_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="slot" id="slot" value="<?php echo htmlspecialchars($params->get('slot')) ?>" />
+		<input type="text" name="slot" id="slot" value="<?php echo htmlspecialchars($params->get('slot') ?: '') ?>" />
 		
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/character/online.php
+++ b/themes/default/character/online.php
@@ -7,13 +7,13 @@
 		<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 		<p>
 			<label for="char_name">Character Name:</label>
-			<input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name')) ?>" />
+			<input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name') ?: '') ?>" />
 			...
 			<label for="char_class">Job Class:</label>
-			<input type="text" name="char_class" id="char_class" value="<?php echo htmlspecialchars($params->get('char_class')) ?>" />
+			<input type="text" name="char_class" id="char_class" value="<?php echo htmlspecialchars($params->get('char_class') ?: '') ?>" />
 			...
 			<label for="guild_name">Guild:</label>
-			<input type="text" name="guild_name" id="guild_name" value="<?php echo htmlspecialchars($params->get('guild_name')) ?>" />
+			<input type="text" name="guild_name" id="guild_name" value="<?php echo htmlspecialchars($params->get('guild_name') ?: '') ?>" />
 
 			<input type="submit" value="Search" />
 			<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/cplog/ban.php
+++ b/themes/default/cplog/ban.php
@@ -5,10 +5,10 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 	<p>
 		<label for="account">Account:</label>
-		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account')) ?>" />
+		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account') ?: '') ?>" />
 		...
 		<label for="banned_by">Banned By:</label>
-		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by')) ?>" />
+		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by') ?: '') ?>" />
 		...
 		<label for="ban_type">Ban Type:</label>
 		<select name="ban_type" id="ban_type">

--- a/themes/default/cplog/changemail.php
+++ b/themes/default/cplog/changemail.php
@@ -21,23 +21,23 @@
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?: '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" />
 		...
 		<label for="request_ip">Request IP:</label>
-		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip')) ?>" />
+		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip') ?: '') ?>" />
 		...
 		<label for="change_ip">Change IP:</label>
-		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip')) ?>" />
+		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="old_email">Old Email:</label>
-		<input type="text" name="old_email" id="old_email" value="<?php echo htmlspecialchars($params->get('old_email')) ?>" />
+		<input type="text" name="old_email" id="old_email" value="<?php echo htmlspecialchars($params->get('old_email') ?: '') ?>" />
 		...
 		<label for="new_email">New Email:</label>
-		<input type="text" name="new_email" id="new_email" value="<?php echo htmlspecialchars($params->get('new_email')) ?>" />
+		<input type="text" name="new_email" id="new_email" value="<?php echo htmlspecialchars($params->get('new_email') ?: '') ?>" />
 		
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/cplog/changepass.php
+++ b/themes/default/cplog/changepass.php
@@ -13,13 +13,13 @@
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?: '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" />
 		...
 		<label for="change_ip">Change IP:</label>
-		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip')) ?>" />
+		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip') ?: '') ?>" />
 		
 		<?php if (!$auth->allowedToSearchCpChangePass): ?>
 		<input type="submit" value="Search" />
@@ -29,10 +29,10 @@
 	<?php if ($auth->allowedToSearchCpChangePass): ?>
 	<p>
 		<label for="old_password">Old Password:</label>
-		<input type="text" name="old_password" id="old_password" value="<?php echo htmlspecialchars($params->get('old_password')) ?>" />
+		<input type="text" name="old_password" id="old_password" value="<?php echo htmlspecialchars($params->get('old_password') ?: '') ?>" />
 		...
 		<label for="new_password">New Password:</label>
-		<input type="text" name="new_password" id="new_password" value="<?php echo htmlspecialchars($params->get('new_password')) ?>" />
+		<input type="text" name="new_password" id="new_password" value="<?php echo htmlspecialchars($params->get('new_password') ?: '') ?>" />
 		
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/cplog/create.php
+++ b/themes/default/cplog/create.php
@@ -13,18 +13,18 @@
 		<?php if ($auth->allowedToSearchCpLoginLogPw): ?>
 		...
 		<label for="password">Password:</label>
-		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password')) ?>" />
+		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password') ?: '') ?>" />
 		<?php endif ?>
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?: '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" />
 		...
 		<label for="ip">IP Address:</label>
-		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip')) ?>" />
+		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip') ?: '') ?>" />
 		...
 		
 		

--- a/themes/default/cplog/ipban.php
+++ b/themes/default/cplog/ipban.php
@@ -5,10 +5,10 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 	<p>
 		<label for="ip">IP Address:</label>
-		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip')) ?>" />
+		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip') ?: '') ?>" />
 		...
 		<label for="banned_by">Banned By:</label>
-		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by')) ?>" />
+		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by') ?: '') ?>" />
 		...
 		<label for="ban_type">Ban Type:</label>
 		<select name="ban_type" id="ban_type">

--- a/themes/default/cplog/login.php
+++ b/themes/default/cplog/login.php
@@ -13,18 +13,18 @@
 		<?php if ($auth->allowedToSearchCpLoginLogPw): ?>
 		...
 		<label for="password">Password:</label>
-		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password')) ?>" />
+		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password') ?: '') ?>" />
 		<?php endif ?>
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?: '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" />
 		...
 		<label for="ip">IP Address:</label>
-		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip')) ?>" />
+		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip') ?: '') ?>" />
 		...
 		<label for="error_code">Error Code:</label>
 		<select name="error_code" id="error_code">

--- a/themes/default/cplog/paypal.php
+++ b/themes/default/cplog/paypal.php
@@ -5,16 +5,16 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 	<p>
 		<label for="txn_id">Transaction ID:</label>
-		<input type="text" name="txn_id" id="txn_id" value="<?php echo htmlspecialchars($params->get('txn_id')) ?>" />
+		<input type="text" name="txn_id" id="txn_id" value="<?php echo htmlspecialchars($params->get('txn_id') ?: '') ?>" />
 		...
 		<label for="parent_txn_id">Parent Transaction ID:</label>
-		<input type="text" name="parent_txn_id" id="parent_txn_id" value="<?php echo htmlspecialchars($params->get('parent_txn_id')) ?>" />
+		<input type="text" name="parent_txn_id" id="parent_txn_id" value="<?php echo htmlspecialchars($params->get('parent_txn_id') ?: '') ?>" />
 		...
 		<label for="status">Status:</label>
-		<input type="text" name="status" id="status" value="<?php echo htmlspecialchars($params->get('status')) ?>" />
+		<input type="text" name="status" id="status" value="<?php echo htmlspecialchars($params->get('status') ?: '') ?>" />
 		...
 		<label for="email">E-mail:</label>
-		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email')) ?>" />
+		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="amount">Amount:</label>
@@ -23,7 +23,7 @@
 			<option value="gt"<?php if ($amount_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($amount_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="amount" id="amount" value="<?php echo htmlspecialchars($params->get('amount')) ?>" />
+		<input type="text" name="amount" id="amount" value="<?php echo htmlspecialchars($params->get('amount') ?: '') ?>" />
 		...
 		<label for="credits">Credits:</label>
 		<select name="credits_op">
@@ -31,10 +31,10 @@
 			<option value="gt"<?php if ($credits_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($credits_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="credits" id="credits" value="<?php echo htmlspecialchars($params->get('credits')) ?>" />
+		<input type="text" name="credits" id="credits" value="<?php echo htmlspecialchars($params->get('credits') ?: '') ?>" />
 		...
 		<label for="account">Account:</label>
-		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account')) ?>" />
+		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="use_processed_after">Process Date Between:</label>

--- a/themes/default/cplog/resetpass.php
+++ b/themes/default/cplog/resetpass.php
@@ -21,16 +21,16 @@
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?: '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?: '') ?>" />
 		...
 		<label for="request_ip">Request IP:</label>
-		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip')) ?>" />
+		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip') ?: '') ?>" />
 		...
 		<label for="reset_ip">Reset IP:</label>
-		<input type="text" name="reset_ip" id="reset_ip" value="<?php echo htmlspecialchars($params->get('reset_ip')) ?>" />
+		<input type="text" name="reset_ip" id="reset_ip" value="<?php echo htmlspecialchars($params->get('reset_ip') ?: '') ?>" />
 		
 		<?php if (!$auth->allowedToSearchCpResetPass): ?>
 		<input type="submit" value="Search" />
@@ -40,10 +40,10 @@
 	<?php if ($auth->allowedToSearchCpResetPass): ?>
 	<p>
 		<label for="old_password">Old Password:</label>
-		<input type="text" name="old_password" id="old_password" value="<?php echo htmlspecialchars($params->get('old_password')) ?>" />
+		<input type="text" name="old_password" id="old_password" value="<?php echo htmlspecialchars($params->get('old_password') ?: '') ?>" />
 		...
 		<label for="new_password">New Password:</label>
-		<input type="text" name="new_password" id="new_password" value="<?php echo htmlspecialchars($params->get('new_password')) ?>" />
+		<input type="text" name="new_password" id="new_password" value="<?php echo htmlspecialchars($params->get('new_password') ?: '') ?>" />
 		
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/donate/index.php
+++ b/themes/default/donate/index.php
@@ -51,7 +51,7 @@
 			<label>
 				Enter an amount you would like to donate:
 				<input class="money-input" type="text" name="amount"
-					value="<?php echo htmlspecialchars($params->get('amount')) ?>"
+					value="<?php echo htmlspecialchars($params->get('amount') ?: 0) ?>"
 					size="<?php echo (strlen((string)+Flux::config('CreditExchangeRate')) * 2) + 2 ?>" />
 				<?php echo htmlspecialchars(Flux::config('DonationCurrency')) ?>
 			</label>

--- a/themes/default/guild/index.php
+++ b/themes/default/guild/index.php
@@ -5,16 +5,16 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="id">Guild ID:</label>
-		<input type="text" name="id" id="id" value="<?php echo htmlspecialchars($params->get('id')) ?>" />
+		<input type="text" name="id" id="id" value="<?php echo htmlspecialchars($params->get('id') ?: '') ?>" />
 		...
 		<label for="guild_name">Guild Name:</label>
-		<input type="text" name="guild_name" id="guild_name" value="<?php echo htmlspecialchars($params->get('guild_name')) ?>" />
+		<input type="text" name="guild_name" id="guild_name" value="<?php echo htmlspecialchars($params->get('guild_name') ?: '') ?>" />
 		...
 		<label for="char_id">Leader ID:</label>
-		<input type="text" name="char_id" id="char_id" value="<?php echo htmlspecialchars($params->get('char_id')) ?>" />
+		<input type="text" name="char_id" id="char_id" value="<?php echo htmlspecialchars($params->get('char_id') ?: '') ?>" />
 		...
 		<label for="master">Leader Name:</label>
-		<input type="text" name="master" id="master" value="<?php echo htmlspecialchars($params->get('master')) ?>" />
+		<input type="text" name="master" id="master" value="<?php echo htmlspecialchars($params->get('master') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="guild_level">Guild Level:</label>
@@ -23,7 +23,7 @@
 			<option value="gt"<?php if ($guild_level_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($guild_level_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="guild_level" id="guild_level" value="<?php echo htmlspecialchars($params->get('guild_level')) ?>" />
+		<input type="text" name="guild_level" id="guild_level" value="<?php echo htmlspecialchars($params->get('guild_level') ?: '') ?>" />
 		...
 		<label for="connect_member">Online Members:</label>
 		<select name="connect_member_op">
@@ -31,7 +31,7 @@
 			<option value="gt"<?php if ($connect_member_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($connect_member_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="connect_member" id="connect_member" value="<?php echo htmlspecialchars($params->get('connect_member')) ?>" />
+		<input type="text" name="connect_member" id="connect_member" value="<?php echo htmlspecialchars($params->get('connect_member') ?: '') ?>" />
 		...
 		<label for="max_member">Capacity:</label>
 		<select name="max_member_op">
@@ -39,7 +39,7 @@
 			<option value="gt"<?php if ($max_member_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($max_member_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="max_member" id="max_member" value="<?php echo htmlspecialchars($params->get('max_member')) ?>" />
+		<input type="text" name="max_member" id="max_member" value="<?php echo htmlspecialchars($params->get('max_member') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="average_lv">Average Level:</label>
@@ -48,7 +48,7 @@
 			<option value="gt"<?php if ($average_lv_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($average_lv_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="average_lv" id="average_lv" value="<?php echo htmlspecialchars($params->get('average_lv')) ?>" />
+		<input type="text" name="average_lv" id="average_lv" value="<?php echo htmlspecialchars($params->get('average_lv') ?: '') ?>" />
 
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/ipban/add.php
+++ b/themes/default/ipban/add.php
@@ -8,13 +8,13 @@
 	<table class="generic-form-table">
 		<tr>
 			<th><label for="list"><?php echo htmlspecialchars(Flux::message('IpbanIpAddressLabel')) ?></label></th>
-			<td><input type="text" name="list" id="list" value="<?php echo htmlspecialchars($params->get('list')) ?>" /></td>
+			<td><input type="text" name="list" id="list" value="<?php echo htmlspecialchars($params->get('list') ?: '') ?>" /></td>
 			<td><p><?php echo htmlspecialchars(Flux::message('IpbanIpAddressInfo')) ?></p></td>
 		</tr>
 		<tr>
 			<th><label for="reason"><?php echo htmlspecialchars(Flux::message('IpbanReasonLabel')) ?></label></th>
 			<td>
-				<textarea name="reason" id="reason" class="reason"><?php echo htmlspecialchars($params->get('reason')) ?></textarea>
+				<textarea name="reason" id="reason" class="reason"><?php echo htmlspecialchars($params->get('reason') ?: '') ?></textarea>
 			</td>
 			<td></td>
 		</tr>

--- a/themes/default/item/index.php
+++ b/themes/default/item/index.php
@@ -5,10 +5,10 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="item_id">Item ID:</label>
-		<input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($params->get('item_id')) ?>" />
+		<input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($params->get('item_id') ?: '') ?>" />
 		...
 		<label for="name">Name:</label>
-		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name')) ?>" />
+		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name') ?: '') ?>" />
 		...
 		<label for="type">Type:</label>
 		<select name="type">
@@ -49,7 +49,7 @@
 			<option value="gt"<?php if ($npc_buy_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($npc_buy_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="npc_buy" id="npc_buy" value="<?php echo htmlspecialchars($params->get('npc_buy')) ?>" />
+		<input type="text" name="npc_buy" id="npc_buy" value="<?php echo htmlspecialchars($params->get('npc_buy') ?: '') ?>" />
 		...
 		<label for="npc_sell">NPC Sell:</label>
 		<select name="npc_sell_op">
@@ -57,7 +57,7 @@
 			<option value="gt"<?php if ($npc_sell_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($npc_sell_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="npc_sell" id="npc_sell" value="<?php echo htmlspecialchars($params->get('npc_sell')) ?>" />
+		<input type="text" name="npc_sell" id="npc_sell" value="<?php echo htmlspecialchars($params->get('npc_sell') ?: '') ?>" />
 		...
 		<label for="weight">Weight:</label>
 		<select name="weight_op">
@@ -65,7 +65,7 @@
 			<option value="gt"<?php if ($weight_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($weight_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="weight" id="weight" value="<?php echo htmlspecialchars($params->get('weight')) ?>" />
+		<input type="text" name="weight" id="weight" value="<?php echo htmlspecialchars($params->get('weight') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="range">Range:</label>
@@ -74,7 +74,7 @@
 			<option value="gt"<?php if ($range_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($range_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="range" id="range" value="<?php echo htmlspecialchars($params->get('range')) ?>" />
+		<input type="text" name="range" id="range" value="<?php echo htmlspecialchars($params->get('range') ?: '') ?>" />
 		...
 		<label for="slots">Slots:</label>
 		<select name="slots_op">
@@ -82,7 +82,7 @@
 			<option value="gt"<?php if ($slots_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($slots_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="slots" id="slots" value="<?php echo htmlspecialchars($params->get('slots')) ?>" />
+		<input type="text" name="slots" id="slots" value="<?php echo htmlspecialchars($params->get('slots') ?: '') ?>" />
 		...
 		<label for="defense">Defense:</label>
 		<select name="defense_op">
@@ -90,7 +90,7 @@
 			<option value="gt"<?php if ($defense_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($defense_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="defense" id="defense" value="<?php echo htmlspecialchars($params->get('defense')) ?>" />
+		<input type="text" name="defense" id="defense" value="<?php echo htmlspecialchars($params->get('defense') ?: '') ?>" />
 	</p>
 	<p>
 		<label for="attack">Attack:</label>
@@ -99,7 +99,7 @@
 			<option value="gt"<?php if ($attack_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($attack_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="attack" id="attack" value="<?php echo htmlspecialchars($params->get('attack')) ?>" />
+		<input type="text" name="attack" id="attack" value="<?php echo htmlspecialchars($params->get('attack') ?: '') ?>" />
 		...
 		<?php if($server->isRenewal): ?>
 		<label for="magic_attack">MATK:</label>
@@ -108,7 +108,7 @@
 			<option value="gt"<?php if ($matk_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($matk_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="magic_attack" id="magic_attack" value="<?php echo htmlspecialchars($params->get('magic_attack')) ?>" />
+		<input type="text" name="magic_attack" id="magic_attack" value="<?php echo htmlspecialchars($params->get('magic_attack') ?: '') ?>" />
 		...
 		<?php endif ?>
 		<label for="refineable">Refineable:</label>
@@ -170,9 +170,9 @@
 		</td>
 		<?php if ($icon=$this->iconImage($item->item_id)): ?>
 			<td width="24"><img src="<?php echo htmlspecialchars($icon) ?>?nocache=<?php echo rand() ?>" /></td>
-			<td><?php echo htmlspecialchars($item->name) ?></td>
+			<td><?php echo htmlspecialchars($item->name ?: '') ?></td>
 		<?php else: ?>
-			<td colspan="2"><?php echo htmlspecialchars($item->name) ?></td>
+			<td colspan="2"><?php echo htmlspecialchars($item->name ?: '') ?></td>
 		<?php endif ?>
 		<td>
 			<?php if ($type=$this->itemTypeText($item->type)): ?>
@@ -197,7 +197,7 @@
 		</td>
 		<td><?php echo number_format((int)$item->price_buy) ?></td>
 		<td><?php echo number_format((int)$item->price_sell) ?></td>
-		<td><?php echo round($item->weight, 1) ?></td>
+		<td><?php echo round($item->weight ?: 0, 1) ?></td>
 		<td><?php echo number_format((int)$item->attack) ?></td>
 		<?php if($server->isRenewal): ?>
 			<td><?php echo number_format((int)$item->magic_attack) ?></td>

--- a/themes/default/itemshop/add.php
+++ b/themes/default/itemshop/add.php
@@ -33,18 +33,18 @@ if (!defined('FLUX_ROOT')) exit;
 	</tr>
 	<tr>
 		<th><label for="cost">Credits</label></th>
-		<td><input type="text" class="short" name="cost" id="cost" value="<?php echo htmlspecialchars($params->get('cost')) ?>" /></td>
+		<td><input type="text" class="short" name="cost" id="cost" value="<?php echo htmlspecialchars($params->get('cost') ?: '') ?>" /></td>
 	</tr>
 	<?php if ($stackable): ?>
 	<tr>
 		<th><label for="qty">Quantity</label></th>
-		<td><input type="text" class="short" name="qty" id="qty" value="<?php echo htmlspecialchars($params->get('qty')) ?>" /></td>
+		<td><input type="text" class="short" name="qty" id="qty" value="<?php echo htmlspecialchars($params->get('qty') ?: '') ?>" /></td>
 	</tr>
 	<?php endif ?>
 	<tr>
 		<th><label for="info">Info</label></th>
 		<td>
-			<textarea name="info" id="info"><?php echo htmlspecialchars($params->get('info')) ?></textarea>
+			<textarea name="info" id="info"><?php echo htmlspecialchars($params->get('info') ?: '') ?></textarea>
 		</td>
 	</tr>
 	<tr>

--- a/themes/default/logdata/feeding.php
+++ b/themes/default/logdata/feeding.php
@@ -6,16 +6,16 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="char_id">Char ID:</label>
-		<input type="text" name="char_id" id="char_id" value="<?php echo htmlspecialchars($params->get('char_id')) ?>" />
+		<input type="text" name="char_id" id="char_id" value="<?php echo htmlspecialchars($params->get('char_id') ?: '') ?>" />
 		...
 		<label for="map">Map:</label>
-		<input type="text" name="map" id="map" value="<?php echo htmlspecialchars($params->get('map')) ?>" />
+		<input type="text" name="map" id="map" value="<?php echo htmlspecialchars($params->get('map') ?: '') ?>" />
 		...
 		<label for="target">Target ID:</label>
-		<input type="text" name="target" id="target" value="<?php echo htmlspecialchars($params->get('target')) ?>" />
+		<input type="text" name="target" id="target" value="<?php echo htmlspecialchars($params->get('target') ?: '') ?>" />
 		...
 		<label for="item_id">Item ID:</label>
-		<input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($params->get('item_id')) ?>" />
+		<input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($params->get('item_id') ?: '') ?>" />
 		...
 		<label>Feeding Type:</label><!-- shared same values -->
 		<?php foreach (Flux::config('FeedingTypes')->toArray() as $feedtype => $typename): ?>
@@ -24,10 +24,10 @@
 		<br />
 		<br />
 		<label for="from_date">Date from:</label>
-		<input type="date" name="from_date" id="from_date" value="<?php echo htmlspecialchars($params->get('from_date')) ?>" />
+		<input type="date" name="from_date" id="from_date" value="<?php echo htmlspecialchars($params->get('from_date') ?: '') ?>" />
 		...
 		<label for="to_date">Date to:</label>
-		<input type="date" name="to_date" id="to_date" value="<?php echo htmlspecialchars($params->get('to_date')) ?>" />
+		<input type="date" name="to_date" id="to_date" value="<?php echo htmlspecialchars($params->get('to_date') ?: '') ?>" />
 		...
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/logdata/login.php
+++ b/themes/default/logdata/login.php
@@ -13,16 +13,16 @@
 	</p>
 	<p>
 		<label for="ip">IP Address:</label>
-		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip')) ?>" />
+		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip') ?: '') ?>" />
 		...
 		<label for="user">Username:</label>
-		<input type="text" name="user" id="user" value="<?php echo htmlspecialchars($params->get('user')) ?>" />
+		<input type="text" name="user" id="user" value="<?php echo htmlspecialchars($params->get('user') ?: '') ?>" />
 		...
 		<label for="log">Log Message:</label>
-		<input type="text" name="log" id="log" value="<?php echo htmlspecialchars($params->get('log')) ?>" />
+		<input type="text" name="log" id="log" value="<?php echo htmlspecialchars($params->get('log') ?: '') ?>" />
 		...
 		<label for="rcode">Response:</label>
-		<input type="text" name="rcode" id="rcode" value="<?php echo htmlspecialchars($params->get('rcode')) ?>" />
+		<input type="text" name="rcode" id="rcode" value="<?php echo htmlspecialchars($params->get('rcode') ?: '') ?>" />
 		
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />

--- a/themes/default/monster/index.php
+++ b/themes/default/monster/index.php
@@ -5,14 +5,14 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="monster_id">Monster ID:</label>
-		<input type="text" name="monster_id" id="monster_id" value="<?php echo htmlspecialchars($params->get('monster_id')) ?>" />
+		<input type="text" name="monster_id" id="monster_id" value="<?php echo htmlspecialchars($params->get('monster_id') ?: '') ?>" />
 		...
 		<label for="name">Name:</label>
-		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name')) ?>" />
+		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name') ?: '') ?>" />
 		...
 		<label for="mvp">MVP:</label>
 		<select name="mvp" id="mvp">
-			<option value="all"<?php if (!($mvpParam=strtolower($params->get('mvp'))) || $mvpParam == 'all') echo ' selected="selected"' ?>>All</option>
+			<option value="all"<?php if (!($mvpParam=strtolower($params->get('mvp') ?: '')) || $mvpParam == 'all') echo ' selected="selected"' ?>>All</option>
 			<option value="yes"<?php if ($mvpParam == 'yes') echo ' selected="selected"' ?>>Yes</option>
 			<option value="no"<?php if ($mvpParam == 'no') echo ' selected="selected"' ?>>No</option>
 		</select>


### PR DESCRIPTION
Fixes #329 

Changes proposed in this Pull Request:
 * PHP 8.1 removed ability for htmlspecialchars to take null. so we need to add a null check to every call that could result in null
 * I found all `htmlspecialchars($params->get(.*))` and added `?: ''` to it. It might be better to fill $params with some default values on pageload, but I'm not a flux guy
