### PR TITLE
Add support for importing configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 !/themes/default
 !/themes/bootstrap
 !/themes/installer
+
+# Import Configs
+/config/import

--- a/index.php
+++ b/index.php
@@ -56,8 +56,10 @@ try {
 
 	// Initialize Flux.
 	Flux::initialize(array(
-		'appConfigFile'      => FLUX_CONFIG_DIR.'/application.php',
-		'serversConfigFile'  => FLUX_CONFIG_DIR.'/servers.php',
+		'appConfigFile'           => FLUX_CONFIG_DIR.'/application.php',
+		'serversConfigFile'       => FLUX_CONFIG_DIR.'/servers.php',
+		'appConfigFileImport'     => FLUX_CONFIG_DIR.'/import/application.php',
+		'serversConfigFileImport' => FLUX_CONFIG_DIR.'/import/servers.php',
 	));
 
 	// Set time limit.

--- a/lib/Flux/Config.php
+++ b/lib/Flux/Config.php
@@ -37,6 +37,22 @@ class Flux_Config {
 	 * @var string
 	 */
 	private $exceptionClass = 'Flux_Error';
+
+	/**
+	 * The list of configuration keys that are cleared if found in the import config.
+	 * These are used for "normal" arrays, not associative arrays. This way is faster than
+	 * checking if each array in the config is associative or not.
+	 * @access private
+	 * @var array
+	 */
+	private $clearKeysOnImport = array(
+		'ThemeName',
+		'PayPalReceiverEmails',
+		'PayPalAllowedHosts',
+		'BanPaymentStatuses',
+		'ShopImageExtensions',
+	);
+
 	
 	/**
 	 * Construct a Flux_Config instance which acts as a more convenient
@@ -194,7 +210,7 @@ class Flux_Config {
 	 * Adds the ability to call set<ConfigDirective>(<Value>) as native methods.
 	 *
 	 * @param string $method
-	 * @param arary $args
+	 * @param array $args
 	 * @access public
 	 */
 	public function __call($method, $args = array())
@@ -219,10 +235,60 @@ class Flux_Config {
 	/**
 	 *
 	 */
-	public function merge(Flux_Config $config, $recursive = true)
+	public function merge(Flux_Config $config, $recursive = true, $distinct = false)
 	{
-		$mergeMethod     = $recursive ? 'array_merge_recursive' : 'array_merge';
-		$this->configArr = $mergeMethod($this->configArr, $config->toArray());
+		if (!$recursive && $distinct) {
+			$this->raise('Cannot merge non-recursively and distinctively at the same time.');
+		}
+		if ($distinct) {
+			$this->configArr = $this->array_merge_recursive_distinct($this->configArr, $config->toArray());
+		} else if ($recursive) {
+			$this->configArr = array_merge_recursive($this->configArr, $config->toArray());
+		} else {
+			$this->configArr = array_merge($this->configArr, $config->toArray());
+		}
+	}
+
+	/**
+	 * array_merge_recursive does indeed merge arrays, but it converts values with duplicate
+	 * keys to arrays rather than overwriting the value in the first array with the duplicate
+	 * value in the second array, as array_merge does. I.e., with array_merge_recursive,
+	 * this happens (documented behavior):
+	 *
+	 * array_merge_recursive(array('key' => 'org value'), array('key' => 'new value'));
+	 *     => array('key' => array('org value', 'new value'));
+	 *
+	 * array_merge_recursive_distinct does not change the datatypes of the values in the arrays.
+	 * Matching keys' values in the second array overwrite those in the first array, as is the
+	 * case with array_merge, i.e.:
+	 *
+	 * array_merge_recursive_distinct(array('key' => 'org value'), array('key' => 'new value'));
+	 *     => array('key' => array('new value'));
+	 *
+	 * Because arrays are appended, not overwritten, we check each key against $clearKeysOnImport,
+	 * and if it matches, we clear the array before importing the new values.
+	 *
+	 * @param array $array1
+	 * @param array $array2
+	 * @return array
+	 * @author Daniel <daniel (at) danielsmedegaardbuus (dot) dk>
+	 * @author Gabriel Sobrinho <gabriel (dot) sobrinho (at) gmail (dot) com>
+	 */
+	public function array_merge_recursive_distinct(array $base, array $import) {
+		$merged = $base;
+
+		foreach ($import as $key => &$value) {
+			if (in_array($key, $this->clearKeysOnImport)) {
+				$merged[$key] = array();
+			}
+			if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
+				$merged[$key] = $this->array_merge_recursive_distinct($merged[$key], $value);
+			} else {
+				$merged[$key] = $value;
+			}
+		}
+
+		return $merged;
 	}
 }
 ?>


### PR DESCRIPTION
This adds support for an "import config", just like in rathena.

There are technically two ways to do this:
1) Share template files and require the user to copy them for their configs, and add the files to .gitignore
This would work well, but I'm not sure how to do this retroactively without telling owners to make a backup of their config before we delete the file in the commit. If we want this to be a backwards-incompatible change, then I say let's go for it. Another drawback is if a new commit adds a new key to the config, the users' config won't be updated automatically; they would have to do it manually.

2) The OTHER way, the uglier way, is the way in this PR. We load the import files (if they exist), and merge them on top of the base config. This is more backwards-compatible, as we won't delete their config files. However, we now have to load 2 extra files, and when we merge the application config we need to check if the value of the key is a sequential array, as the merge function would **append** the arrays, which is not what we want. So we clear these values before merging.
For the servers config, the whole config is an array, so if the import file exists, we should just replace the entire config. 

As you can see, option 2 is a lot more confusing, and the changes below definitely show it.

For example, this is what my import files are:

<details>
<summary>config/import/application.php</summary>

```php
<?php

// this is an import configuration file
return array(
    'PasswordMinUpper'		=> 0,		// Number of upper-case letters to require in passwords.
    'PasswordMinLower'		=> 0,		// Number of lower-case letters to require in passwords.
    'PasswordMinNumber'		=> 0,		// Number of numbers to require in passwords.
    'AllowUserInPassword'	=> true,	// Whether or not to allow the password to contain the username. (NOTE: A case-insensitive search is performed)
    'AllowDuplicateEmails'	=> true,	// Whether or not to allow duplicate e-mails to be used in registration. (See Mailer config options)
    'PincodeEnabled'		=> false,	// Whether or not the pincode system is enabled in your server. (Check your char_athena.conf file. Enabled by default.)
    
);
?>
```
</details>

<details>
<summary>config/import/servers.php</summary>

```php
<?php
return array(
	// Example server configuration. You may have more arrays like this one to
	// specify multiple server groups (however they should share the same login
	// server whilst they are allowed to have multiple char/map pairs).
	array(
		'ServerName'     => 'my custom ro',
		// Global database configuration (excludes logs database configuration).
		'DbConfig'       => array(
			//'Socket'     => '/tmp/mysql.sock',
			//'Port'       => 3306,
			//'Encoding'   => 'utf8', // Connection encoding -- use whatever here your MySQL tables collation is.
			'Convert'    => 'utf8',
				// -- 'Convert' option only works when 'Encoding' option is specified and iconv (http://php.net/iconv) is available.
				// -- It specifies the encoding to convert your MySQL data to on the website (most likely needs to be utf8)
			'Hostname'   => 'dbhost',
			'Username'   => 'ragnarok',
			'Password'   => 'ragnarok',
			'Database'   => 'password',
			'Persistent' => true,
			'Timezone'   => null // Example: '+0:00' is UTC.
			// The possible values of 'Timezone' is as documented from the MySQL website:
			// "The value can be given as a string indicating an offset from UTC, such as '+10:00' or '-6:00'."
			// "The value can be given as a named time zone, such as 'Europe/Helsinki', 'US/Eastern', or 'MET'." (see below continuation!)
			// **"Named time zones can be used only if the time zone information tables in the mysql database have been created and populated."
		),
		// This is kept separate because many people choose to have their logs
		// database accessible under different credentials, and often on a
		// different server entirely to ensure the reliability of the log data.
		'LogsDbConfig'   => array(
			//'Socket'     => '/tmp/mysql.sock',
			//'Port'       => 3306,
			//'Encoding'   => null, // Connection encoding -- use whatever here your MySQL tables collation is.
			'Convert'    => 'utf8',
				// -- 'Convert' option only works when 'Encoding' option is specified and iconv (http://php.net/iconv) is available.
				// -- It specifies the encoding to convert your MySQL data to on the website (most likely needs to be utf8)
			'Hostname'   => 'dbhost',
			'Username'   => 'ragnarok',
			'Password'   => 'ragnarok',
			'Database'   => 'password',
			'Persistent' => true,
			'Timezone'   => null // Possible values is as described in the comment in DbConfig.
		),
		// Login server configuration.
		'LoginServer'    => array(
			'Address'  => '127.0.0.1',
			'Port'     => 6900,
			'UseMD5'   => false,
			'NoCase'   => true, // rA account case-sensitivity; Default: Case-INsensitive (true).
			'GroupID'  => 0,    // Default account group ID during registration.
			//'Database' => 'ragnarok'
		),
		'CharMapServers' => array(
			array(
				'ServerName'      => 'NitrousRO',
				'Renewal'         => false,
				'MaxCharSlots'    => 9,
				'DateTimezone'    => null, // Specifies game server's timezone for this char/map pair. (See: http://php.net/timezones)
				//'ResetDenyMaps'   => 'sec_pri', // Defaults to 'sec_pri'. This value can be an array of map names.
				//'Database'        => 'ragnarok', // Defaults to DbConfig.Database
				'ExpRates' => array(
					'Base'        => 100, // Rate at which (base) exp is given
					'Job'         => 100, // Rate at which job exp is given
					'Mvp'         => 100  // MVP bonus exp rate
				),
				'DropRates' => array(
					// If drop rate was below this amount and bonus is applied to it, the bonus can't make it exceed this amount.
					'DropRateCap' => 9000,
					// The rate the common items (in the ETC tab, besides card) are dropped
					'Common'      => 100,
					'CommonBoss'  => 100,
					'CommonMVP'   => 100,
					'CommonMin'   => 1,
					'CommonMax'   => 10000,
					// The rate healing items (that restore HP or SP) are dropped
					'Heal'        => 100,
					'HealBoss'    => 100,
					'HealMVP'     => 100,
					'HealMin'     => 1,
					'HealMax'     => 10000,
					// The rate usable items (in the item tab other then healing items) are dropped
					'Useable'     => 100,
					'UseableBoss' => 100,
					'UseableMVP'  => 100,
					'UseableMin'  => 1,
					'UseableMax'  => 10000,
					// The rate at which equipment is dropped
					'Equip'       => 100,
					'EquipBoss'   => 100,
					'EquipMVP'    => 100,
					'EquipMin'    => 1,
					'EquipMax'    => 10000,
					// The rate at which cards are dropped
					'Card'        => 100,
					'CardBoss'    => 100,
					'CardMVP'     => 100,
					'CardMin'     => 1,
					'CardMax'     => 10000,
					// The rate adjustment for the MVP items that the MVP gets directly in their inventory
					'MvpItem'     => 100,
					'MvpItemMin'  => 1,
					'MvpItemMax'  => 10000,
					// 0 - official order (Show message "Note: Only one MVP drop will be rewarded.") , 2 - all items
					'MvpItemMode' => 0,
				),
				'CharServer'      => array(
					'Address'     => '127.0.0.1',
					'Port'        => 6121
				),
				'MapServer'       => array(
					'Address'     => '127.0.0.1',
					'Port'        => 5121
				),
				// -- WoE days and times --
				// First parameter: Starding day 0=Sunday / 1=Monday / 2=Tuesday / 3=Wednesday / 4=Thursday / 5=Friday / 6=Saturday
				// Second parameter: Starting hour in 24-hr format.
				// Third paramter: Ending day (possible value is same as starting day).
				// Fourth (final) parameter: Ending hour in 24-hr format.
				// ** (Note, invalid times are ignored silently.)
				'WoeDayTimes'   => array(
					//array(0, '12:00', 0, '14:00'), // Example: Starts Sunday 12:00 PM and ends Sunday 2:00 PM
					//array(3, '14:00', 3, '15:00')  // Example: Starts Wednesday 2:00 PM and ends Wednesday 3:00 PM
				),
				// Modules and/or actions to disallow access to during WoE.
				'WoeDisallow'   => array(
					array('module' => 'character', 'action' => 'online'),  // Disallow access to "Who's Online" page during WoE.
					array('module' => 'character', 'action' => 'mapstats') // Disallow access to "Map Statistics" page during WoE.
				)
			)
		)
	)
);
?>
```
</details>