### PR TITLE
Update `status.php` Online PEAK

### DIFF
--- a/modules/server/status.php
+++ b/modules/server/status.php
@@ -27,7 +27,7 @@ else {
 			$res = $sth->fetch();
 
 			if(Flux::config('EnablePeakDisplay')){
-				$sth = $server->connection->getStatement("SELECT `users` FROM {$server->charMapDatabase}.$tbl");
+				$sth = $server->connection->getStatement("SELECT MAX(`users`) FROM {$server->charMapDatabase}.$tbl");
 				$sth->execute();
 				$peak = $sth->fetch();
 			}

--- a/modules/server/status.php
+++ b/modules/server/status.php
@@ -2,7 +2,7 @@
 if (!defined('FLUX_ROOT')) exit;
 
 $title = Flux::message('ServerStatusTitle');
-$cache = FLUX_DATA_DIR.'/tmp/ServerStatus.cache';
+$cache = FLUX_ROOT.'/data/tmp/ServerStatus.cache';
 $tbl = Flux::config('FluxTables.OnlinePeakTable'); 
 
 


### PR DESCRIPTION
SELECT MAX(`users`) FROM {$server->charMapDatabase}.$tbl since if you dont use max it will select the first table which is not the highest peak of online.

Fixes # .

Changes proposed in this Pull Request:
 * Fix a SQL Query in status.php online peak
 * ?
 * ?
