### PR TITLE
Fix null check for baseuri

### DIFF
--- a/lib/Flux.php
+++ b/lib/Flux.php
@@ -328,7 +328,7 @@ class Flux {
 
 		// Sanitize BaseURI. (leading forward slash is mandatory.)
 		$baseURI = $config->get('BaseURI');
-		if ($baseURI) {
+		if (!is_null($baseURI)) {
 			if (strlen($baseURI) && $baseURI[0] != '/') {
 				$config->set('BaseURI', "/$baseURI");
 			}


### PR DESCRIPTION
Fixes #351.

I added a check if baseURI was null, and if not, handle it. This causes an issue where baseURI is empty, because the `if ($string)` check returns false if `$string` is empty. Because users' BaseURI was empty, we never set it to the default `/`, causing this issue.

