### PR TITLE
Added installation requirement checks

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,10 +1,4 @@
 <?php
-if (version_compare(PHP_VERSION, '5.2.1', '<')) {
-	echo '<h2>Error</h2>';
-	echo '<p>PHP 5.2.1 or higher is required to use Flux Control Panel.</p>';
-	echo '<p>You are running '.PHP_VERSION.'</p>';
-	exit;
-}
 
 // Time started.
 define('__START__', microtime(true));
@@ -47,13 +41,6 @@ require_once 'Flux/PermissionError.php';
 // Vendor libraries.
 
 try {
-	if (!extension_loaded('pdo')) {
-		throw new Flux_Error('The PDO extension is required to use Flux, please make sure it is installed along with the PDO_MYSQL driver.');
-	}
-	elseif (!extension_loaded('pdo_mysql')) {
-		throw new Flux_Error('The PDO_MYSQL driver for the PDO extension must be installed to use Flux.  Please consult the PHP manual for installation instructions.');
-	}
-
 	// Initialize Flux.
 	Flux::initialize(array(
 		'appConfigFile'           => FLUX_CONFIG_DIR.'/application.php',
@@ -114,7 +101,9 @@ try {
 
 	foreach ($directories as $directory => $directoryFunction) {
 		$directory = realpath($directory);
-		if (!is_writable($directory))
+		if (!is_dir($directory))
+			mkdir($directory, 0600);
+		if (!is_writable($directory) && is_dir($directory))
 			throw new Flux_PermissionError("The $directoryFunction directory '$directory' is not writable.  Remedy with `chmod 0600 $directory`");
 		if (Flux::config('RequireOwnership') && function_exists('posix_getuid') && fileowner($directory) != $uid)
 			throw new Flux_PermissionError("The $directoryFunction directory '$directory' is not owned by the executing user.  Remedy with `chown -R ".posix_geteuid().":".posix_geteuid()." $directory`");

--- a/lib/Flux.php
+++ b/lib/Flux.php
@@ -269,7 +269,9 @@ class Flux {
 	{
 		$basename  = basename(str_replace(' ', '', ucwords(str_replace(array('/', '\\', '_'), ' ', $filename))), '.php').'.cache.php';
 		$cachefile = FLUX_DATA_DIR."/tmp/$basename";
-
+		$directory = FLUX_DATA_DIR.'/tmp';
+		if (!is_dir($directory))
+			mkdir($directory, 0600);
 		if ($cache && file_exists($cachefile) && filemtime($cachefile) > filemtime($filename)) {
 			return unserialize(file_get_contents($cachefile, false, null, 28));
 		}

--- a/modules/install/index.php
+++ b/modules/install/index.php
@@ -6,6 +6,41 @@ require_once 'Flux/Installer/SchemaPermissionError.php';
 // Force debug mode off here.
 Flux::config('DebugMode', false);
 
+// Define minimum requirements.
+$requiredExtensions = array(
+	'pdo',
+	'pdo_mysql',
+	'curl',
+	//'gd',
+	//'dom',
+	//'json',
+	//'mbstring',
+	//'zip',
+	'xml',
+	'xmlreader',
+	'mysqli'
+);
+
+$minimumVersionCheck = [
+	'php' => [
+		'required' => '5.2.1',
+		'recommended' => '8.0.0'
+	],
+	'mysql' => [
+		'required' => '5.0.0',
+		'recommended' => '5.6.2'
+	]
+];
+$sth = $server->connection->getStatement("SELECT VERSION() AS mysql_version, CURRENT_USER() AS mysql_user");
+$sth->execute();
+$res = $sth->fetch();
+
+$permissionsChecks = [
+	FLUX_DATA_DIR.'/logs'		=> 'log storage',
+	FLUX_DATA_DIR.'/itemshop'	=> 'item shop image',
+	FLUX_DATA_DIR.'/tmp'		=> 'temporary'
+];
+
 if ($session->installerAuth) {
 	if ($params->get('logout')) {
 		$session->setInstallerAuthData(false);

--- a/themes/installer/install/index.php
+++ b/themes/installer/install/index.php
@@ -1,18 +1,81 @@
 <?php if (!$session->installerAuth): ?>
-	<form action="<?php echo $this->url ?>" method="post" class="row g-3">
-		<p>
-			Please enter your <em>installer password</em> to continue with the update.
-		</p>
-		<div class="col-auto">
-			<label for="installer_password">Password:</label>
+	<?php $success = TRUE; ?>
+	<h3>Requirement Checks</h3>
+
+	<p>Before you can continue with the installation, you must meet the following requirements.</p>
+
+
+	<h4>Base Requirements</h4>
+	<table class="table">
+		<tr><td style="width:20%;">PHP Version</td><td>
+			<?php if ( version_compare( PHP_VERSION, $minimumVersionCheck['php']['required'] ) >= 0 ): ?>
+				<span class="text-success"><?php echo PHP_VERSION ?></span>
+			<?php else: $success = FALSE; ?>
+				<span class="text-danger">You are not running a compatible version of PHP. You need PHP <?php echo $minimumVersionCheck['php']['required']; ?> or above (<?php echo $requirements['php']['recommended']; ?> or above recommended). You should contact your hosting provider or system administrator to ask for an upgrade.</span>
+			<?php endif ?>
+		</td><td><?php echo $minimumVersionCheck['php']['required'] ?> required</td><td><?php echo $minimumVersionCheck['php']['recommended'] ?> recommended</td></tr>
+		<tr><td>MySQL Version</td><td>
+			<?php if ( version_compare( $res->mysql_version, $minimumVersionCheck['mysql']['required'] ) >= 0 ): ?>
+				<span class="text-success"><?php echo $res->mysql_version ?></span>
+			<?php else: $success = FALSE; ?>
+				<span class="text-danger">You are not running a compatible version of MySQL. You need MySQL <?php echo $minimumVersionCheck['mysql']['required']; ?> or above (<?php echo $requirements['mysql']['recommended']; ?> or above recommended). You should contact your hosting provider or system administrator to ask for an upgrade.</span>
+			<?php endif ?>
+			</td><td><?php echo $minimumVersionCheck['mysql']['required'] ?> required</td><td><?php echo $minimumVersionCheck['mysql']['recommended'] ?> recommended</td></tr>
+	</table>
+	<p class="pb-4">The Base Requirements are the minimum requirements to run FluxCP. If you do not meet these requirements, FluxCP will not run.</p>
+
+	<h4>PHP Extensions</h4>
+	<table class="table">
+		<?php foreach($requiredExtensions as $requirement): ?>
+			<tr><td style="width:20%;"><?php echo $requirement ?></td><td>
+				<?php if ( extension_loaded($requirement) ): ?>
+					<span class="text-success">Installed</span>
+				<?php else: $success = FALSE; ?>
+					<span class="text-danger">Not Installed</span>
+				<?php endif ?>
+			</td></tr>
+		<?php endforeach ?>
+	</table>
+	<p class="pb-4">The PHP Extensions are required for FluxCP to operate correctly. Most of these extensions are required for normal use, some are optional based on configs. For the sake of "proper" installs, all are set as required.</p>
+
+
+	<h4>File Permissions</h4>
+
+	<table class="table">
+		<?php foreach($permissionsChecks as $pathCheck => $pathDesc): ?>
+			<?php $pathCheck = realpath($pathCheck); ?>
+			<tr><td style="width:20%;"><?php echo $pathCheck ?></td><td>
+				<?php if ( is_writable($pathCheck) ): ?>
+					<span class="text-success"><?php echo $pathDesc ?> is writable</span>
+				<?php else: $success = FALSE; ?>
+					<span class="text-danger"><?php echo $pathDesc ?> is not writable. Remedy with `chmod 0600 <?php echo $pathDesc ?>`</span>
+				<?php endif ?>
+			</td></tr>
+		<?php endforeach ?>
+	</table>
+	<p class="pb-4">The File Permissions are required for FluxCP to operate correctly. If you do not meet these requirements, FluxCP will not run.</p>
+
+
+	<?php if($success == TRUE): ?>
+		<form action="<?php echo $this->url ?>" method="post" class="row g-3">
+			<p>
+				Please enter your <em>installer password</em> to continue with the update.
+			</p>
+			<div class="col-auto">
+				<label for="installer_password">Password:</label>
+			</div>
+			<div class="col-auto">
+				<input class="form-control" type="password" id="installer_password" name="installer_password" />
+			</div>
+			<div class="col-auto">
+				<button type="submit" class="btn btn-success">Authenticate</button>
+			</div>
+		</form>
+	<?php else: ?>
+		<div class="alert alert-danger mb-5">
+			<strong>Error:</strong> It looks like you do not meet the requirements to run FluxCP. Please fix the issues above and try again.
 		</div>
-		<div class="col-auto">
-			<input class="form-control" type="password" id="installer_password" name="installer_password" />
-		</div>
-		<div class="col-auto">
-			<button type="submit" class="btn btn-success">Authenticate</button>
-		</div>
-	</form>
+	<?php endif; ?>
 <?php else: ?>
 	<?php if (isset($permissionError)): ?>
 		<h2 class="error">MySQL Permission Error Encountered</h2>


### PR DESCRIPTION
Fixes #65 

Changes proposed in this Pull Request:
 * Provides checks for minimum versions of PHP and MySQL.
 * Provides checks for PHP Extensions.
 * Provides checks for directory permissions.

If any of the checks fail, the "installer password" form does not display.
![chrome_Wgv1pF0h2P](https://github.com/rathena/FluxCP/assets/4101952/c1f45d7a-4d21-4933-ae67-161c8d4a5b2c)


Otherwise, the installation process may continue.
![chrome_ndgzebc3Qv](https://github.com/rathena/FluxCP/assets/4101952/e4f2c35b-ecdc-4889-bbac-a80b69750915)

It's only taken 7 years to close this Issue. Not bad!


