### PR TITLE
Given GMs the ability to change Credit value in SD Ticket

### DIFF
--- a/modules/servicedesk/staffview.php
+++ b/modules/servicedesk/staffview.php
@@ -2,9 +2,9 @@
 if (!defined('FLUX_ROOT')) exit;
 $this->loginRequired();
 $ticket_id = trim($params->get('ticketid'));
-$tbl = Flux::config('FluxTables.ServiceDeskTable'); 
-$tbla = Flux::config('FluxTables.ServiceDeskATable'); 
-$tblsettings = Flux::config('FluxTables.ServiceDeskSettingsTable'); 
+$tbl = Flux::config('FluxTables.ServiceDeskTable');
+$tbla = Flux::config('FluxTables.ServiceDeskATable');
+$tblsettings = Flux::config('FluxTables.ServiceDeskSettingsTable');
 
 $sth = $server->connection->getStatement("SELECT * FROM {$server->loginDatabase}.$tblsettings WHERE account_id = ?");
 $sth->execute(array($session->account->account_id));
@@ -32,9 +32,9 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 		$sql = "INSERT INTO {$server->loginDatabase}.$tbla (ticket_id, author, text, action, ip, isstaff)";
 		$sql .= "VALUES (?, ?, ?, 0, ?, 1)";
 		$sth = $server->connection->getStatement($sql);
-		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $_SERVER['REMOTE_ADDR'])); 
+		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $_SERVER['REMOTE_ADDR']));
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET lastreply = 'Staff' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 				require_once 'Flux/Mailer.php';
 				$name = $session->loginAthenaGroup->serverName;
 				$mail = new Flux_Mailer();
@@ -43,12 +43,12 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 					'Staff'			=> $staffsess->prefered_name
 				));
 				if ($sent) {
-					$this->redirect($this->url('servicedesk','staffview', array('ticketid' => $ticket_id)));	
+					$this->redirect($this->url('servicedesk','staffview', array('ticketid' => $ticket_id)));
 				}
 				else {
 					$fail = true;
 				}
-	
+
 	}elseif($_POST['secact']=='2'){
 		if($_POST['response']=='Leave as-is to skip text response.' || $_POST['response'] == '' || $_POST['response'] == NULL || !isset($_POST['response'])){
 			$text = '0';
@@ -58,7 +58,7 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 		$sql = "INSERT INTO {$server->loginDatabase}.$tbla (ticket_id, author, text, action, ip, isstaff)";
 		$sql .= "VALUES (?, ?, ?, 0, ?, 1)";
 		$sth = $server->connection->getStatement($sql);
-		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $_SERVER['REMOTE_ADDR'])); 
+		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $_SERVER['REMOTE_ADDR']));
 				require_once 'Flux/Mailer.php';
 				$name = $session->loginAthenaGroup->serverName;
 				$mail = new Flux_Mailer();
@@ -67,24 +67,24 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 					'Staff'			=> $staffsess->prefered_name
 				));
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET lastreply = 'Staff' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 		$this->redirect($this->url('servicedesk','staffindex'));
-	
+
 	}elseif($_POST['secact']=='3'){
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET status = 'Resolved' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
-		
+		$sth->execute(array($ticket_id));
+
 		if($_POST['response']=='Leave as-is to skip text response.' || $_POST['response'] == '' || $_POST['response'] == NULL || !isset($_POST['response'])){
 			$text = '0';
 		} else {
 			$text = htmlentities($_POST['response']);
 		}
 		$action='Ticket Resolved';
-		
+
 		$sql = "INSERT INTO {$server->loginDatabase}.$tbla (ticket_id, author, text, action, ip, isstaff)";
 		$sql .= "VALUES (?, ?, ?, ?, ?, 1)";
 		$sth = $server->connection->getStatement($sql);
-		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR'])); 
+		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR']));
 				require_once 'Flux/Mailer.php';
 				$name = $session->loginAthenaGroup->serverName;
 				$mail = new Flux_Mailer();
@@ -93,9 +93,9 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 					'Staff'			=> $staffsess->prefered_name
 				));
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET lastreply = 'Staff' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 		$this->redirect($this->url('servicedesk','staffindex'));
-	
+
 	}elseif($_POST['secact']=='4'){
 		if($staffsess->team=='1'){
 			$escalateto=2;
@@ -104,7 +104,7 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 			$escalateto=3;
 		}
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET team = ? WHERE ticket_id = ?");
-		$sth->execute(array($escalateto, $ticket_id)); 
+		$sth->execute(array($escalateto, $ticket_id));
 
 		if($_POST['response']=='Leave as-is to skip text response.' || $_POST['response'] == '' || $_POST['response'] == NULL || !isset($_POST['response'])){
 			$text = '0';
@@ -115,14 +115,14 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 		$sql = "INSERT INTO {$server->loginDatabase}.$tbla (ticket_id, author, text, action, ip, isstaff)";
 		$sql .= "VALUES (?, ?, ?, ?, ?, 1)";
 		$sth = $server->connection->getStatement($sql);
-		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR'])); 
+		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR']));
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET lastreply = 'Staff' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 		$this->redirect($this->url('servicedesk','staffindex'));
 
 	}elseif($_POST['secact']=='5'){
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET status = 'Closed' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 		if($_POST['response']=='Leave as-is to skip text response.' || $_POST['response'] == '' || $_POST['response'] == NULL || !isset($_POST['response'])){
 			$text = '0';
 		} else {
@@ -132,22 +132,22 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 		$sql = "INSERT INTO {$server->loginDatabase}.$tbla (ticket_id, author, text, action, ip, isstaff)";
 		$sql .= "VALUES (?, ?, ?, ?, ?, 1)";
 		$sth = $server->connection->getStatement($sql);
-		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR'])); 
+		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR']));
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET lastreply = 'Staff' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 		$this->redirect($this->url('servicedesk','staffindex'));
-		
+
 	}elseif($_POST['secact']=='6'){
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET status = 'Pending' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
-		
+		$sth->execute(array($ticket_id));
+
 		if($_POST['response']=='Leave as-is to skip text response.' || $_POST['response'] == '' || $_POST['response'] == NULL || !isset($_POST['response'])){
 			$text = '0';
 		} else {
 			$text = htmlentities($_POST['response']);
 		}
 		$action='Ticket Re-Opened by a member of the '. Flux::message('SDGroup'. $staffsess->team) .' group.';
-		
+
 		$sql = "INSERT INTO {$server->loginDatabase}.$tbla (ticket_id, author, text, action, ip, isstaff)";
 		$sql .= "VALUES (?, ?, ?, ?, ?, 1)";
 		$sth = $server->connection->getStatement($sql);
@@ -160,25 +160,26 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 					'Staff'			=> $staffsess->prefered_name
 				));
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET lastreply = 'Staff' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 		$this->redirect($this->url('servicedesk','staffindex'));
-		
+
 	}elseif($_POST['secact']=='7'){
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET status = 'Resolved' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
-		
+		$sth->execute(array($ticket_id));
+		$give_credits = intval($_POST['award_credits']);
+
 		if($_POST['response']=='Leave as-is to skip text response.' || $_POST['response'] == '' || $_POST['response'] == NULL || !isset($_POST['response'])){
 			$text = '0';
 		} else {
 			$text = htmlentities($_POST['response']);
 		}
-		$action = sprintf('Ticket Resolved, %d Credits Awarded.', Flux::config('SDCreditReward'));
-		
+		$action = sprintf('Ticket Resolved, %d Credits Awarded.', $give_credits);
+
 		$sql = "INSERT INTO {$server->loginDatabase}.$tbla (ticket_id, author, text, action, ip, isstaff)";
 		$sql .= "VALUES (?, ?, ?, ?, ?, 1)";
 		$sth = $server->connection->getStatement($sql);
-		$res = $server->loginServer->depositCredits($_POST['account_id'], Flux::config('SDCreditReward'));
-		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR'])); 
+		$res = $server->loginServer->depositCredits($_POST['account_id'], $give_credits);
+		$sth->execute(array($ticket_id, $_POST['staff_reply_name'], $text, $action, $_SERVER['REMOTE_ADDR']));
 				require_once 'Flux/Mailer.php';
 				$name = $session->loginAthenaGroup->serverName;
 				$mail = new Flux_Mailer();
@@ -187,15 +188,13 @@ if(isset($_POST['postreply']) && $_POST['postreply'] == 'gogolol'){
 					'Staff'			=> $staffsess->prefered_name
 				));
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET lastreply = 'Staff' WHERE ticket_id = ?");
-		$sth->execute(array($ticket_id)); 
+		$sth->execute(array($ticket_id));
 		$this->redirect($this->url('servicedesk','staffindex'));
 	}
 }
 
-
-
-$tbl = Flux::config('FluxTables.ServiceDeskTable'); 
-$tbla = Flux::config('FluxTables.ServiceDeskATable'); 
+$tbl = Flux::config('FluxTables.ServiceDeskTable');
+$tbla = Flux::config('FluxTables.ServiceDeskATable');
 $sql = "SELECT * FROM {$server->loginDatabase}.$tbl WHERE ticket_id = $ticket_id";
 $rep = $server->connection->getStatement($sql);
 $rep->execute();
@@ -226,7 +225,7 @@ $repr = $server->connection->getStatement($sqlr);
 $repr->execute();
 $replylist = $repr->fetchAll();
 
-$tblc = Flux::config('FluxTables.ServiceDeskCatTable'); 
+$tblc = Flux::config('FluxTables.ServiceDeskCatTable');
 $sth  = $server->connection->getStatement("SELECT name FROM {$server->loginDatabase}.$tblc WHERE cat_id = ?");
 $sth->execute(array($trow->category));
 $ticketlist = $sth->fetchAll();

--- a/themes/default/servicedesk/staffview.php
+++ b/themes/default/servicedesk/staffview.php
@@ -1,10 +1,10 @@
 <?php
 if (!defined('FLUX_ROOT')) exit;
-$this->loginRequired(); 
+$this->loginRequired();
 ?>
 <?php if($ticketlist): ?>
 <h2><?php echo Flux::message('SDHeaderID') ?><?php echo htmlspecialchars($trow->ticket_id) ?> - <?php echo htmlspecialchars($trow->subject) ?> - Staff Area</h2>
-	<table class="vertical-table" width="100%"> 
+	<table class="vertical-table" width="100%">
 		<tbody>
 		<tr>
 			<th>Account</th>
@@ -62,10 +62,10 @@ $this->loginRequired();
 		</tbody>
 	</table>
 	<br />
-	
+
 	<?php if($replylist): ?>
 	<?php foreach($replylist as $rrow): ?>
-	<table class="vertical-table" width="100%"> 
+	<table class="vertical-table" width="100%">
 		<tbody>
 		<tr>
 			<th width="100">Reply By</th>
@@ -80,7 +80,7 @@ $this->loginRequired();
 			<th>Response</th>
 			<td><?php echo nl2br(stripslashes($rrow->text)) ?></td>
 		</tr>
-		
+
 		<?php endif ?>
 		<?php if($rrow->action!='0'): ?>
 		<tr>
@@ -96,7 +96,7 @@ $this->loginRequired();
 	</table><br />
 	<?php endforeach ?>
 	<?php else: ?>
-		<table class="vertical-table" width="100%"> 
+		<table class="vertical-table" width="100%">
 		<tbody>
 		<tr>
 			<th>There are no replies to this ticket.</th>
@@ -108,7 +108,7 @@ $this->loginRequired();
 
 	<?php if($trow->status!='Resolved' || $trow->status!='Closed'): ?>
 	<form action="<?php echo $this->urlWithQs ?>" method="post">
-	<table class="vertical-table" width="100%"> 
+	<table class="vertical-table" width="100%">
 		<tbody>
 		<tr>
 			<th width="100">Response</th>
@@ -122,7 +122,7 @@ $this->loginRequired();
 					<tr><td><?php echo Flux::message('SDRespTable2') ?>:</td><td><input type="radio" name="secact" value="2" /></td></tr>
 					<tr><td><?php echo Flux::message('SDRespTable3') ?>:</td><td><input type="radio" name="secact" value="3" /></td></tr>
 					<?php if(Flux::config('SDEnableCreditRewards')):?>
-					<tr><td><?php echo Flux::message('SDRespTable7') ?>:</td><td><input type="radio" name="secact" value="7" /></td></tr>
+					<tr><td><?php echo Flux::message('SDRespTable7') ?>: <input type="number" value="<?php echo Flux::config('SDCreditReward') ?>" name="award_credits" style="width:50px;"/></td><td><input type="radio" name="secact" value="7" /></td></tr>
 					<?php endif ?>
 					<?php if($trow->team<3): ?>
 						<tr><td><?php echo Flux::message('SDRespTable4') ?>:</td><td><input type="radio" name="secact" value="4" /></td></tr>
@@ -152,8 +152,7 @@ $this->loginRequired();
 	</table>
 	</form>
 	<?php endif ?>
-	
-	
+
 <?php else: ?>
 	<p>
 		<?php echo htmlspecialchars(Flux::message('SDHuh')) ?>


### PR DESCRIPTION
Fixes #288  .

Changes proposed in this Pull Request:
 * Creates a small textbox for a GM to input the number of credits to give the user when closing a Support Ticket.
 * Defaults to whatever the value is of config `SDCreditReward`.
 * Contains lots of whitespace removal along the way.

![image](https://github.com/rathena/FluxCP/assets/4101952/5db56c32-db0e-4309-991a-84b86853bc81)

