### PR TITLE
Display query error in debug mode if no items found

### DIFF
--- a/themes/default/item/index.php
+++ b/themes/default/item/index.php
@@ -231,5 +231,9 @@
 </table>
 <?php echo $paginator->getHTML() ?>
 <?php else: ?>
-<p>No items found. <a href="javascript:history.go(-1)">Go back</a>.</p>
+	<p>No items found. <a href="javascript:history.go(-1)">Go back</a>.</p>
+	<?php if(Flux::config('Debug')): ?>
+		<?php $msg = sprintf('Error info: %s', print_r($sth->errorInfo(), true)); ?>
+		<?php echo $msg; ?>
+	<?php endif ?>
 <?php endif ?>


### PR DESCRIPTION
Fixes #216  .

Changes proposed in this Pull Request:
 * Provides the query error on the item_db index page when Debug mode is turned on.
 * If there is no query error, the page will still only state "no items found".