### PR TITLE
Fix auto-login after registration when captcha enabled

### DIFF
--- a/modules/account/create.php
+++ b/modules/account/create.php
@@ -73,7 +73,7 @@ if (count($_POST)) {
 				$session->setMessageData($message);
 			}
 			else {
-				$session->login($server->serverName, $username, $password, false);
+				$session->login($server->serverName, $username, $password, $code);
 				$session->setMessageData(Flux::message('AccountCreated'));
 				$discordMessage = 'Account Created.';
 			}


### PR DESCRIPTION
Changes proposed in this Pull Request:
 * When captcha is enabled, automatic authorization after registration does not work.
 Before it was send "false" as security code and users get error after registration.