### PR TITLE
Config to display CashPoints instead of Credits

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -90,6 +90,7 @@ return array(
 	'BackwardYears'				=> 60,						// (Visual) The number of years to display behind the current year in date inputs.
 	'ColumnSortAscending'		=> ' ▲',					// (Visual) Text displayed for ascending sorted column names.
 	'ColumnSortDescending'		=> ' ▼',					// (Visual) Text displayed for descending sorted column names.
+	'DisplayCashPoints'			=> false,					// Whether or not to display "Cash Points" instead of the player's "Credits" in the control panel.
 	'CreditExchangeRate'		=> 1.0,						// The rate at which credits are exchanged for dollars.
 	'MinDonationAmount'			=> 2.0,						// Minimum donation amount. (NOTE: Actual donations made that are less than this account won't be exchanged)
 	'DonationCurrency'			=> 'USD',					// Preferred donation currency. Only donations made in this currency will be processed for credit deposits.

--- a/modules/account/view.php
+++ b/modules/account/view.php
@@ -240,5 +240,14 @@ if ($account) {
 
 	$itemAttributes = Flux::config('Attributes')->toArray();
 	$type_list = Flux::config('ItemTypes')->toArray();
+
+	if(Flux::config('DisplayCashPoints')) {
+		$regTable = 'acc_reg_num';
+		$sql = "SELECT * FROM {$server->loginDatabase}.{$regTable} WHERE `key` = '#CASHPOINTS' AND account_id = ?";
+		$sth = $server->connection->getStatement($sql);
+		$sth->execute(array($accountID));
+		$account->balance = $sth->fetch()->value;
+	}
+
 }
 ?>


### PR DESCRIPTION
Fixes #367, Fixes #310

Changes proposed in this Pull Request:
 * Adds a config switch in application.php `DisplayCashPoints` that, when `true`, will display the player's CashPoints in account/view.php instead of their Credits.
