### PR TITLE
Send Exception to Discord

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -240,6 +240,7 @@ return array(
     'DiscordSendOnNewTicket'    => true, // Sends a channel message when someone submits a new ticket to the Service Desk
     'DiscordSendOnWebCommand'   => true, // Sends a channel message when someone uses the Web Command feature in FluxCP
     'DiscordSendOnMarketing'    => true, // Sends a channel message when someone uses the Send Email feature in FluxCP
+	'DiscordSendOnErrorException' => true, // Sends a channel message when an exception is thrown
 
 	'TinyMCEKey'				=> 'no-key',				// Register for a key at https://www.tiny.cloud/my-account/dashboard/
 

--- a/index.php
+++ b/index.php
@@ -178,7 +178,9 @@ catch (Exception $e) {
 		if(Flux::config('DiscordSendOnErrorException')) {
 			sendtodiscord(Flux::config('DiscordWebhookURL'), '```ansi
 [2;31mERROR[0m
-Exception: '. $e->getMessage() .'```');
+Error: '. get_class($e) .'
+Exception: '. $e->getMessage() .'
+File: '. $e->getFile() .':'. $e->getLine() .'```');
 		}
 	}
 

--- a/index.php
+++ b/index.php
@@ -174,6 +174,14 @@ catch (Exception $e) {
 		}
 	}
 
+	if(Flux::config('DiscordUseWebhook')) {
+		if(Flux::config('DiscordSendOnErrorException')) {
+			sendtodiscord(Flux::config('DiscordWebhookURL'), '```ansi
+[2;31mERROR[0m
+Exception: '. $e->getMessage() .'```');
+		}
+	}
+
 	require_once FLUX_CONFIG_DIR.'/error.php';
 	define('__ERROR__', 1);
 	include $errorFile;


### PR DESCRIPTION
Closes #390  .

Changes proposed in this Pull Request:
 * Makes use of Discord as a method of alerting admins to page exceptions.

This will not report generic PHP errors, only errors within the application that would throw the dreaded white page of death. I.E:
![image](https://github.com/rathena/FluxCP/assets/4101952/5c11b239-6839-4ced-b46e-a646f0e6a20e)

This change will also continue to send exceptions to Discord on each page load until the issue is resolved. This doesn't happen often enough to be an annoyance if FluxCP is configured correctly.

![Discord_AsEGWp2Fdz](https://github.com/rathena/FluxCP/assets/4101952/c30fc56c-8116-4810-8c32-b6135cdacda8)

