### PR TITLE
Add Acolyte to equip_jobs

### DIFF
--- a/config/equip_jobs.php
+++ b/config/equip_jobs.php
@@ -8,6 +8,7 @@ return array(
 		'job_swordman' => 'Swordman',
 		'job_mage' => 'Mage',
 		'job_archer' => 'Archer',
+		'job_acolyte' => 'Acolyte',
 		'job_merchant' => 'Merchant',
 		'job_thief' => 'Thief',
 		'job_knight' => 'Knight',


### PR DESCRIPTION
Fixes #371

Changes proposed in this Pull Request:
 * Added `'job_acolyte' => 'Acolyte',` to equip_jobs.php

Not sure how we never noticed that.