### PR TITLE
(FIX) deprecated messages and minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Flux Control Panel (FluxCP) for rAthena servers.
 
 Requirements
 ---------
-* PHP 5.2
+* PHP 7.0
 * PDO and PDO-MYSQL extensions for PHP5 (including PHP_MYSQL support)
 * MySQL 5
 * Optional: GD2 (for guild emblems and registration CAPTCHA)

--- a/modules/cplog/ban.php
+++ b/modules/cplog/ban.php
@@ -10,8 +10,8 @@ $sqlpartial .= "WHERE 1=1 ";
 $sqlpartial .= "AND a.banned_by IS NOT NULL ";
 $bind        = array();
 
-$account     = trim($params->get('account'));
-$bannedBy    = trim($params->get('banned_by'));
+$account     = trim($params->get('account') ?? '');
+$bannedBy    = trim($params->get('banned_by') ?? '');
 $banType     = $params->get('ban_type');
 $banDate     = $params->get('ban_date');
 $banUntil    = $params->get('ban_until_date');

--- a/modules/cplog/changemail.php
+++ b/modules/cplog/changemail.php
@@ -13,12 +13,12 @@ $requestAfter  = $params->get('request_after_date');
 $requestBefore = $params->get('request_before_date');
 $changeAfter   = $params->get('change_after_date');
 $changeBefore  = $params->get('change_before_date');
-$accountID     = trim($params->get('account_id'));
-$username      = trim($params->get('username'));
-$oldEmail      = trim($params->get('old_email'));
-$newEmail      = trim($params->get('new_email'));
-$requestIP     = trim($params->get('request_ip'));
-$changeIP      = trim($params->get('change_ip'));
+$accountID     = trim($params->get('account_id') ?? '');
+$username      = trim($params->get('username') ?? '');
+$oldEmail      = trim($params->get('old_email') ?? '');
+$newEmail      = trim($params->get('new_email') ?? '');
+$requestIP     = trim($params->get('request_ip') ?? '');
+$changeIP      = trim($params->get('change_ip') ?? '');
 
 if ($requestAfter) {
 	$sqlpartial .= 'AND request_date >= ? ';
@@ -60,7 +60,7 @@ $sth->execute($bind);
 $paginator = $this->getPaginator($sth->fetch()->total);
 $paginator->setSortableColumns(array(
 	'log.account_id', 'userid',
-	'change_date' => 'desc', 'change_ip', 
+	'change_date' => 'desc', 'change_ip',
 	'request_date' => 'desc', 'request_ip'
 ));
 

--- a/modules/cplog/changepass.php
+++ b/modules/cplog/changepass.php
@@ -11,9 +11,9 @@ $bind        = array();
 // Password change searching.
 $changeAfter   = $params->get('change_after_date');
 $changeBefore  = $params->get('change_before_date');
-$accountID     = trim($params->get('account_id'));
-$username      = trim($params->get('username'));
-$changeIP      = trim($params->get('change_ip'));
+$accountID     = trim($params->get('account_id') ?? '');
+$username      = trim($params->get('username') ?? '');
+$changeIP      = trim($params->get('change_ip') ?? '');
 
 if ($changeAfter) {
 	$sqlpartial .= 'AND change_date >= ? ';
@@ -40,7 +40,7 @@ if ($auth->allowedToSearchCpChangePass) {
 	$oldPassword = $params->get('old_password');
 	$newPassword = $params->get('new_password');
 	$useMD5      = $session->loginAthenaGroup->loginServer->config->getUseMD5();
-	
+
 	if ($oldPassword) {
 		if ($useMD5) {
 			$oldPassword = md5($oldPassword);

--- a/modules/cplog/create.php
+++ b/modules/cplog/create.php
@@ -9,8 +9,8 @@ $bind          = array();
 
 $password    = $params->get('password');
 $accountID   = (int)$params->get('account_id');
-$username    = trim($params->get('username'));
-$ipAddress   = trim($params->get('ip'));
+$username    = trim($params->get('username') ?? '');
+$ipAddress   = trim($params->get('ip') ?? '');
 $loginAfter  = $params->get('login_after_date');
 $loginBefore = $params->get('login_before_date');
 

--- a/modules/cplog/ipban.php
+++ b/modules/cplog/ipban.php
@@ -7,8 +7,8 @@ $ipBanTable = Flux::config('FluxTables.IpBanTable');
 $sqlpartial = "WHERE 1=1 ";
 $bind       = array();
 
-$ipAddress   = trim($params->get('ip'));
-$bannedBy    = trim($params->get('banned_by'));
+$ipAddress   = trim($params->get('ip') ?? '');
+$bannedBy    = trim($params->get('banned_by') ?? '');
 $banType     = $params->get('ban_type');
 $banDate     = $params->get('ban_date');
 $banUntil    = $params->get('ban_until_date');

--- a/modules/cplog/paypal.php
+++ b/modules/cplog/paypal.php
@@ -14,10 +14,10 @@ $sqlpartial .= "WHERE (p.server_name = ? OR p.server_name IS NULL OR p.server_na
 $bind            = array($session->loginAthenaGroup->serverName);
 $opMapping       = array('eq' => '=', 'gt' => '>', 'lt' => '<');
 $opValues        = array_keys($opMapping);
-$txnID           = trim($params->get('txn_id'));
-$parentTxnID     = trim($params->get('parent_txn_id'));
-$paymentStatus   = trim($params->get('status'));
-$emailAddress    = trim($params->get('email'));
+$txnID           = trim($params->get('txn_id') ?? '');
+$parentTxnID     = trim($params->get('parent_txn_id') ?? '');
+$paymentStatus   = trim($params->get('status') ?? '');
+$emailAddress    = trim($params->get('email') ?? '');
 $amount          = $params->get('amount');
 $amountOp        = $params->get('amount_op');
 $credits         = $params->get('credits');

--- a/modules/cplog/resetpass.php
+++ b/modules/cplog/resetpass.php
@@ -13,10 +13,10 @@ $requestAfter  = $params->get('request_after_date');
 $requestBefore = $params->get('request_before_date');
 $resetAfter    = $params->get('reset_after_date');
 $resetBefore   = $params->get('reset_before_date');
-$accountID     = trim($params->get('account_id'));
-$username      = trim($params->get('username'));
-$requestIP     = trim($params->get('request_ip'));
-$resetIP       = trim($params->get('reset_ip'));
+$accountID     = trim($params->get('account_id') ?? '');
+$username      = trim($params->get('username') ?? '');
+$requestIP     = trim($params->get('request_ip') ?? '');
+$resetIP       = trim($params->get('reset_ip') ?? '');
 
 if ($requestAfter) {
 	$sqlpartial .= 'AND request_date >= ? ';
@@ -47,7 +47,7 @@ if ($auth->allowedToSearchCpResetPass) {
 	$oldPassword = $params->get('old_password');
 	$newPassword = $params->get('new_password');
 	$useMD5      = $session->loginAthenaGroup->loginServer->config->getUseMD5();
-	
+
 	if ($oldPassword) {
 		if ($useMD5) {
 			$oldPassword = md5($oldPassword);
@@ -71,7 +71,7 @@ $sth->execute($bind);
 $paginator = $this->getPaginator($sth->fetch()->total);
 $paginator->setSortableColumns(array(
 	'log.account_id', 'userid',
-	'reset_date' => 'desc', 'reset_ip', 
+	'reset_date' => 'desc', 'reset_ip',
 	'request_date' => 'desc', 'request_ip'
 ));
 

--- a/modules/cplog/txnview.php
+++ b/modules/cplog/txnview.php
@@ -19,15 +19,15 @@ $txn = $sth->fetch();
 
 if ($txn) {
 	$title = "Viewing PayPal Transaction ({$txn->txn_id}, status: {$txn->payment_status})";
-	
+
 	$txnLogFile = FLUX_DATA_DIR."/logs/transactions/{$txn->txn_type}/{$txn->payment_status}/{$txn->txn_id}.log.php";
 	if (file_exists($txnLogFile)) {
 		$txnFileLog = file($txnLogFile);
-		
+
 		if (count($txnFileLog) && preg_match('/<\?php.*?\?>/', $txnFileLog[0])) {
 			array_shift($txnFileLog);
 		}
-		
+
 		$txnFileLog = implode('', $txnFileLog);
 	}
 }

--- a/modules/ipban/edit.php
+++ b/modules/ipban/edit.php
@@ -68,7 +68,7 @@ if (count($_POST)) {
 				$errorMessage = sprintf(Flux::message('IpbanAlreadyBanned'), $ipban2->list);
 			}
 		}
-		
+
 		if (empty($errorMessage)) {
 			if ($server->loginServer->removeIpBan($session->account->account_id, $editReason, $ipban->list)
 				&& $server->loginServer->addIpBan($session->account->account_id, $reason, $rtime, $list)

--- a/modules/item/index.php
+++ b/modules/item/index.php
@@ -16,13 +16,13 @@ try {
 	$tableName = "{$server->charMapDatabase}.items";
 	$tempTable = new Flux_TemporaryTable($server->connection, $tableName, $fromTables);
 	$shopTable = Flux::config('FluxTables.ItemShopTable');
-	
+
 	// Statement parameters, joins and conditions.
 	$bind        = array();
 	$sqlpartial  = "LEFT OUTER JOIN {$server->charMapDatabase}.$shopTable ON $shopTable.nameid = items.id ";
 	$sqlpartial .= "WHERE 1=1 ";
 	$itemID      = $params->get('item_id');
-	
+
 	if ($itemID) {
 		$sqlpartial .= "AND items.id = ? ";
 		$bind[]      = $itemID;
@@ -50,7 +50,7 @@ try {
 		$refineable   = $params->get('refineable');
 		$forSale      = $params->get('for_sale');
 		$custom       = $params->get('custom');
-		
+
 		if ($itemName) {
 			$sqlpartial .= "AND (name_english LIKE ? OR name_english = ?) ";
 			$bind[]      = "%$itemName%";
@@ -70,7 +70,7 @@ try {
 				} else {
 					$sqlpartial .= 'AND type IS NULL ';
 				}
-				
+
 				if (count($itemTypeSplit) == 2 && $itemType2) {
 					$itemTypes2 = Flux::config('ItemSubTypes')->toArray();
 					if (array_key_exists($itemType, $itemTypes2) && array_key_exists($itemType2, $itemTypes2[$itemType]) && $itemTypes2[$itemType][$itemType2]) {
@@ -83,17 +83,17 @@ try {
 			} else {
 				$typeName   = preg_quote($itemType, '/');
 				$itemTypes  = preg_grep("/.*?$typeName.*?/i", Flux::config('ItemTypes')->toArray());
-				
+
 				if (count($itemTypes)) {
 					$itemTypes   = array_keys($itemTypes);
 					$sqlpartial .= "AND (";
 					$partial     = '';
-					
+
 					foreach ($itemTypes as $id) {
 						$partial .= "type = ? OR ";
 						$bind[]   = $id;
 					}
-					
+
 					$partial     = preg_replace('/\s*OR\s*$/', '', $partial);
 					$sqlpartial .= "$partial) ";
 				} else {
@@ -117,7 +117,7 @@ try {
 				}
 			}
 		}
-		
+
 		if (in_array($npcBuyOp, $opValues) && trim($npcBuy) != '') {
 			$op = $opMapping[$npcBuyOp];
 			if ($op == '=' && $npcBuy === '0') {
@@ -128,7 +128,7 @@ try {
 				$bind[]      = $npcBuy;
 			}
 		}
-		
+
 		if (in_array($npcSellOp, $opValues) && trim($npcSell) != '') {
 			$op = $opMapping[$npcSellOp];
 			if ($op == '=' && $npcSell === '0') {
@@ -139,7 +139,7 @@ try {
 				$bind[]      = $npcSell;
 			}
 		}
-		
+
 		if (in_array($weightOp, $opValues) && trim($weight) != '') {
 			$op = $opMapping[$weightOp];
 			if ($op == '=' && $weight === '0') {
@@ -150,7 +150,7 @@ try {
 				$bind[]      = $weight;
 			}
 		}
-		
+
 		if (!$server->isRenewal && in_array($attackOp, $opValues) && trim($attack) != '') {
 			$op = $opMapping[$attackOp];
 			if ($op == '=' && $attack === '0') {
@@ -161,7 +161,7 @@ try {
 				$bind[]      = $attack;
 			}
 		}
-		
+
 		if (in_array($defenseOp, $opValues) && trim($defense) != '') {
 			$op = $opMapping[$defenseOp];
 			if ($op == '=' && $defense === '0') {
@@ -172,7 +172,7 @@ try {
 				$bind[]      = $defense;
 			}
 		}
-		
+
 		if (in_array($rangeOp, $opValues) && trim($range) != '') {
 			$op = $opMapping[$rangeOp];
 			if ($op == '=' && $range === '0') {
@@ -183,7 +183,7 @@ try {
 				$bind[]      = $range;
 			}
 		}
-		
+
 		if (in_array($slotsOp, $opValues) && trim($slots) != '') {
 			$op = $opMapping[$slotsOp];
 			if ($op == '=' && $slots === '0') {
@@ -194,7 +194,7 @@ try {
 				$bind[]      = $slots;
 			}
 		}
-		
+
 		if ($refineable) {
 			if ($refineable == 'yes') {
 				$sqlpartial .= "AND refineable > 0 ";
@@ -203,7 +203,7 @@ try {
 				$sqlpartial .= "AND IFNULL(refineable, 0) < 1 ";
 			}
 		}
-		
+
 		if ($forSale) {
 			if ($forSale == 'yes') {
 				$sqlpartial .= "AND $shopTable.cost > 0 ";
@@ -212,7 +212,7 @@ try {
 				$sqlpartial .= "AND IFNULL($shopTable.cost, 0) < 1 ";
 			}
 		}
-		
+
 		if ($custom) {
 			if ($custom == 'yes') {
 				$sqlpartial .= "AND origin_table LIKE '%item_db2' ";
@@ -222,11 +222,11 @@ try {
 			}
 		}
 	}
-	
+
 	// Get total count and feed back to the paginator.
 	$sth = $server->connection->getStatement("SELECT COUNT(DISTINCT items.id) AS total FROM $tableName $sqlpartial");
 	$sth->execute($bind);
-	
+
 	$paginator = $this->getPaginator($sth->fetch()->total);
 	$sortable = array(
 		'item_id' => 'asc', 'name', 'type', 'subtype', 'price_buy', 'price_sell', 'weight',
@@ -236,7 +236,7 @@ try {
 		$sortable[] = 'magic_attack';
 	}
 	$paginator->setSortableColumns($sortable);
-	
+
 	$col  = "items.id AS item_id, name_english AS name, type, subtype, ";
 	$col .= "price_buy, weight/10 AS weight, ";
 	$col .= "defense, `range`, slots, refineable, cost, $shopTable.id AS shop_item_id, ";
@@ -247,12 +247,12 @@ try {
 
 	$sql  = $paginator->getSQL("SELECT $col FROM $tableName $sqlpartial GROUP BY items.id, $shopTable.id");
 	$sth  = $server->connection->getStatement($sql);
-	
+
 	$sth->execute($bind);
 	$items = $sth->fetchAll();
-	
+
 	$authorized = $auth->actionAllowed('item', 'view');
-	
+
 	foreach ($items as $item) {
 		// Equip location
 		$equip_location = array();
@@ -260,7 +260,7 @@ try {
 		foreach($equip_list as $eq_loc) if($item->$eq_loc) $equip_location[] = $eq_loc;
 		$item->equip_location = $equip_location;
 	}
-	
+
 	if ($items && count($items) === 1 && $authorized && Flux::config('SingleMatchRedirectItem')) {
 		$this->redirect($this->url('item', 'view', array('id' => $items[0]->item_id)));
 	}
@@ -270,7 +270,7 @@ catch (Exception $e) {
 		// Ensure table gets dropped.
 		$tempTable->drop();
 	}
-	
+
 	// Raise the original exception.
 	$class = get_class($e);
 	throw new $class($e->getMessage());

--- a/modules/item/iteminfo.php
+++ b/modules/item/iteminfo.php
@@ -1,6 +1,8 @@
 <?php
 if (!defined('FLUX_ROOT')) exit;
+
 require_once 'Flux/FileLoad.php';
+
 $itemDescTable = Flux::config('FluxTables.ItemDescTable');
 $title = 'Item Info';
 $fileLoad = new FileLoad();
@@ -10,7 +12,7 @@ if($files->get('iteminfo')) {
     $itemInfo = FLUX_ROOT . '/itemInfo.lua';
     $is_loaded = $fileLoad->load($files->get('iteminfo'), $itemInfo);
     if($is_loaded === true) {
-        $fp = @fopen($itemInfo, 'r'); 
+        $fp = @fopen($itemInfo, 'r');
         if($fp){ $array = explode("\n", fread($fp, filesize($itemInfo))); }
         fclose($fp);
         $ca = count($array);

--- a/modules/logdata/feeding.php
+++ b/modules/logdata/feeding.php
@@ -13,38 +13,45 @@ $map = $params->get('map');
 $datefrom = $params->get('from_date');
 $dateto = $params->get('to_date');
 $type = array();
+
 if ($params->get('type')) {
 	$type = $params->get('type')->toArray();
 	$type = array_keys($type);
 }
+
 if ($char_id) {
 	$sql_param_str .= '`char_id`=?';
 	$sql_params[] = $char_id;
 }
+
 if ($item_id) {
 	if ($sql_param_str)
 		$sql_param_str .= ' AND ';
 	$sql_param_str .= '`item_id`=?';
 	$sql_params[] = $item_id;
 }
+
 if ($map) {
 	if ($sql_param_str)
 		$sql_param_str .= ' AND ';
 	$sql_param_str .= '`map` LIKE ?';
 	$sql_params[] = "%$map%";
 }
+
 if ($target) {
 	if ($sql_param_str)
 		$sql_param_str .= ' AND ';
 	$sql_param_str .= '`target_class`=?';
 	$sql_params[] = "$target";
 }
+
 if (count($type)) {
 	if ($sql_param_str)
 		$sql_param_str .= ' AND ';
 	$sql_param_str .= '`type` IN ('.implode(',', array_fill(0, count($type), '?')).')';
 	$sql_params = array_merge($sql_params, $type);
 }
+
 if ($datefrom || $dateto) {
 	if ($sql_param_str)
 		$sql_param_str .= ' AND ';

--- a/modules/logdata/login.php
+++ b/modules/logdata/login.php
@@ -8,10 +8,10 @@ $bind       = array();
 
 $dateAfter  = $params->get('log_after_date');
 $dateBefore = $params->get('log_before_date');
-$ipAddress  = trim($params->get('ip'));
-$username   = trim($params->get('user'));
-$logMessage = trim($params->get('log'));
-$response   = trim($params->get('rcode'));
+$ipAddress  = trim($params->get('ip') ?? '');
+$username   = trim($params->get('user') ?? '');
+$logMessage = trim($params->get('log') ?? '');
+$response   = trim($params->get('rcode') ?? '');
 
 if ($dateAfter) {
 	$sqlpartial .= 'AND time >= :dateAfter ';

--- a/modules/monster/index.php
+++ b/modules/monster/index.php
@@ -13,7 +13,7 @@ try {
 		$fromTables = array("{$server->charMapDatabase}.mob_db", "{$server->charMapDatabase}.mob_db2");
 	}
 	$tempTable  = new Flux_TemporaryTable($server->connection, $tableName, $fromTables);
-	
+
 	// Statement parameters, joins and conditions.
 	$bind        = array();
 	$sqlpartial  = "WHERE 1=1 ";
@@ -32,7 +32,7 @@ try {
 		$element        = $params->get('element');
 		$mvp            = strtolower($params->get('mvp') ?: '');
 		$custom         = $params->get('custom');
-		
+
 		if ($monsterName) {
 			$sqlpartial .= "AND ((name_english LIKE ? OR name_english = ?) OR (name_japanese LIKE ? OR name_japanese = ?)) ";
 			$bind[]      = "%$monsterName%";
@@ -51,17 +51,17 @@ try {
 			} else {
 				$sizeName = preg_quote($size, '/');
 				$sizes = preg_grep("/.*?$sizeName.*?/i", Flux::config('MonsterSizes')->toArray());
-				
+
 				if (count($sizes)) {
 					$sizes = array_keys($sizes);
 					$sqlpartial .= "AND (";
 					$partial     = '';
-					
+
 					foreach ($sizes as $id) {
 						$partial .= "size = ? OR ";
 						$bind[]   = $id;
 					}
-					
+
 					$partial     = preg_replace('/\s*OR\s*$/', '', $partial);
 					$sqlpartial .= "$partial) ";
 				}
@@ -78,17 +78,17 @@ try {
 			} else {
 				$raceName = preg_quote($race, '/');
 				$races = preg_grep("/.*?$raceName.*?/i", Flux::config('MonsterRaces')->toArray());
-				
+
 				if (count($races)) {
 					$races = array_keys($races);
 					$sqlpartial .= "AND (";
 					$partial     = '';
-					
+
 					foreach ($races as $id) {
 						$partial .= "race = ? OR ";
 						$bind[]   = $id;
 					}
-					
+
 					$partial     = preg_replace('/\s*OR\s*$/', '', $partial);
 					$sqlpartial .= "$partial) ";
 				}
@@ -108,52 +108,63 @@ try {
 				} else {
 					$sqlpartial .= 'AND element IS NULL ';
 				}
-				
+
 				if (count($elementSplit) == 2 && $elementLevel) {
 					$sqlpartial .= "AND element_level = ?" ;
 					$bind[]      = $elementLevel;
 				}
 			}
 		}
-		
+
 		if ($mvp == 'yes') {
 			$sqlpartial .= 'AND mvp_exp > 0 ';
 		}
 		elseif ($mvp == 'no') {
-			$sqlpartial .= 'AND mvp_exp = 0 ';
+			$sqlpartial .= 'AND mvp_exp IS NULL ';
 		}
-		
-		if ($custom) {
-			if ($custom == 'yes') {
-				$sqlpartial .= "AND origin_table LIKE '%mob_db2' ";
+
+		if($server->isRenewal) {
+			if ($custom) {
+				if ($custom == 'yes') {
+					$sqlpartial .= "AND origin_table LIKE '%mob_db2_re' ";
+				}
+				elseif ($custom == 'no') {
+					$sqlpartial .= "AND origin_table LIKE '%mob_db_re' ";
+				}
 			}
-			elseif ($custom == 'no') {
-				$sqlpartial .= "AND origin_table LIKE '%mob_db' ";
+		} else {
+			if ($custom) {
+				if ($custom == 'yes') {
+					$sqlpartial .= "AND origin_table LIKE '%mob_db2' ";
+				}
+				elseif ($custom == 'no') {
+					$sqlpartial .= "AND origin_table LIKE '%mob_db' ";
+				}
 			}
 		}
 	}
-	
+
 	// Get total count and feed back to the paginator.
 	$sth = $server->connection->getStatement("SELECT COUNT(monsters.ID) AS total FROM $tableName $sqlpartial");
 	$sth->execute($bind);
-	
+
 	$paginator = $this->getPaginator($sth->fetch()->total);
 	$paginator->setSortableColumns(array(
 		'monster_id' => 'asc', 'name_english', 'name_japanese', 'level', 'hp', 'size', 'race', 'base_exp', 'job_exp', 'origin_table'
 	));
-	
+
 	$col  = "origin_table, monsters.ID AS monster_id, name_english, name_japanese, ";
 	$col .= "level, hp, size, race, element, element_level, ";
 	$col .= "base_exp, job_exp, mvp_exp";
-	
+
 	$sql  = $paginator->getSQL("SELECT $col FROM $tableName $sqlpartial");
 	$sth  = $server->connection->getStatement($sql);
-	
+
 	$sth->execute($bind);
 	$monsters = $sth->fetchAll();
-	
+
 	$authorized = $auth->actionAllowed('monster', 'view');
-	
+
 	if ($monsters && count($monsters) === 1 && $authorized && Flux::config('SingleMatchRedirectMobs')) {
 		$this->redirect($this->url('monster', 'view', array('id' => $monsters[0]->monster_id)));
 	}
@@ -163,7 +174,7 @@ catch (Exception $e) {
 		// Ensure table gets dropped.
 		$tempTable->drop();
 	}
-	
+
 	// Raise the original exception.
 	$class = get_class($e);
 	throw new $class($e->getMessage());

--- a/modules/news/add.php
+++ b/modules/news/add.php
@@ -4,12 +4,12 @@ $title = Flux::message('NewsAddTitle');
 
 // Form values.
 $news	= Flux::config('FluxTables.CMSNewsTable');
-$title	= trim($params->get('news_title'));
-$body	= trim($params->get('news_body'));
-$link	= trim($params->get('news_link'));
-$author	= trim($params->get('news_author'));
+$title	= trim($params->get('news_title') ?? '');
+$body	= trim($params->get('news_body') ?? '');
+$link	= trim($params->get('news_link') ?? '');
+$author	= trim($params->get('news_author') ?? '');
 
-$tinymce_key = Flux::config('TinyMCEKey'); 
+$tinymce_key = Flux::config('TinyMCEKey');
 
 if(count($_POST)){
     if($title === '') {
@@ -27,12 +27,12 @@ if(count($_POST)){
 				$news_link = "http://$link";
 			}
 		}
-		
+
         $sql = "INSERT INTO {$server->loginDatabase}.$news (title, body, link, author, created, modified)";
-        $sql .= "VALUES (?, ?, ?, ?, NOW(), NOW())"; 
+        $sql .= "VALUES (?, ?, ?, ?, NOW(), NOW())";
         $sth = $server->connection->getStatement($sql);
         $sth->execute(array($title, $body, $link, $author));
-        
+
         $session->setMessageData(Flux::message('CMSNewsAdded'));
         if ($auth->actionAllowed('news', 'index')) {
             $this->redirect($this->url('news','index'));

--- a/modules/news/delete.php
+++ b/modules/news/delete.php
@@ -1,5 +1,6 @@
 <?php
-if (!defined('FLUX_ROOT')) exit;  
+if (!defined('FLUX_ROOT')) exit;
+
 $news		= Flux::config('FluxTables.CMSNewsTable');
 $id			= $params->get('id');
 $sql		= "SELECT title FROM {$server->loginDatabase}.$news WHERE id = ?";
@@ -12,9 +13,9 @@ if ($new) {
     $sth = $server->connection->getStatement("DELETE FROM {$server->loginDatabase}.$news WHERE id = ?");
     $sth->execute(array($id));
 	$session->setMessageData(sprintf(Flux::message('CMSNewsDeleted'), $new->title));
-}
-else {
+} else {
 	$session->setMessageData(Flux::message('CMSNewsNotFound'));
 }
+
 $this->redirect($redirect);
 ?>

--- a/modules/news/edit.php
+++ b/modules/news/edit.php
@@ -1,5 +1,6 @@
 <?php
 if (!defined('FLUX_ROOT')) exit;
+
 $title = Flux::message('CMSNewsEditTitle');
 $news	= Flux::config('FluxTables.CMSNewsTable');
 $id		= $params->get('id');
@@ -8,20 +9,20 @@ $sth	= $server->connection->getStatement($sql);
 $sth->execute(array($id));
 $new	= $sth->fetch();
 
-$tinymce_key = Flux::config('TinyMCEKey'); 
+$tinymce_key = Flux::config('TinyMCEKey');
 
 if($new) {
     $title	= $new->title;
     $body	= $new->body;
     $link	= $new->link;
     $author	= $new->author;
-    
+
     if(count($_POST)) {
         $title	= trim($params->get('news_title'));
         $body 	= trim($params->get('news_body'));
 		$link 	= trim($params->get('news_link'));
 		$author = trim($params->get('news_author'));
-        
+
         if($title === '') {
             $errorMessage = Flux::Message('CMSNewsTitleError');
         }
@@ -37,20 +38,20 @@ if($new) {
 					$news_link = "http://$news_link";
 				}
 			}
-			
+
 			$sql = "UPDATE {$server->loginDatabase}.$news SET ";
 			$sql .= "title = ?, body = ?, link = ?, author = ?, modified = NOW() ";
 			$sql .= "WHERE id = ?";
 			$sth = $server->connection->getStatement($sql);
 			$sth->execute(array($title, $body, $link, $author, $id));
-			
+
 			$session->setMessageData(Flux::message('CMSNewsUpdated'));
 			if ($auth->actionAllowed('news', 'index')) {
 				$this->redirect($this->url('news','index'));
 			}
 			else {
 				$this->redirect();
-			}           
+			}
 		}
     }
 }

--- a/modules/news/index.php
+++ b/modules/news/index.php
@@ -1,9 +1,11 @@
 <?php
 if (!defined('FLUX_ROOT')) exit;
+
 $newslimit = (int)Flux::config('CMSNewsLimit');
 $newstype = (int)Flux::config('CMSNewsType');
+
 if($newstype == '1'){
-	$news = Flux::config('FluxTables.CMSNewsTable'); 
+	$news = Flux::config('FluxTables.CMSNewsTable');
 	$sql = "SELECT title, body, link, author, created, modified FROM {$server->loginDatabase}.$news ORDER BY id DESC LIMIT $newslimit";
 	$sth = $server->connection->getStatement($sql);
 	$sth->execute();
@@ -14,5 +16,7 @@ if($newstype == '1'){
 		$i = 0;
 		$xml = new SimpleXmlElement($content);
 	}
-} else {exit('Check CMSNewsType configuration option..');}
+} else {
+    exit('Check CMSNewsType configuration option..');
+}
 ?>

--- a/modules/pages/add.php
+++ b/modules/pages/add.php
@@ -4,9 +4,9 @@ $this->loginRequired();
 $title = Flux::message('CMSPageAddTitle');
 
 $pages	= Flux::config('FluxTables.CMSPagesTable'); 
-$title	= trim($params->get('page_title'));
-$path	= trim($params->get('page_path'));
-$body	= trim($params->get('page_body'));
+$title	= trim($params->get('page_title') ?? '');
+$path	= trim($params->get('page_path') ?? '');
+$body	= trim($params->get('page_body') ?? '');
 
 $tinymce_key = Flux::config('TinyMCEKey'); 
 

--- a/modules/ranking/alchemist.php
+++ b/modules/ranking/alchemist.php
@@ -6,7 +6,7 @@ $alchemistJobs = Flux::config('AlchemistJobClasses')->toArray();
 $jobClass      = $params->get('jobclass');
 $bind          = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/ranking/blacksmith.php
+++ b/modules/ranking/blacksmith.php
@@ -6,7 +6,7 @@ $blacksmithJobs = Flux::config('BlacksmithJobClasses')->toArray();
 $jobClass       = $params->get('jobclass');
 $bind           = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/ranking/death.php
+++ b/modules/ranking/death.php
@@ -6,7 +6,7 @@ $classes  = Flux::config('JobClasses')->toArray();
 $jobClass = $params->get('jobclass');
 $bind     = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/ranking/homunculus.php
+++ b/modules/ranking/homunculus.php
@@ -6,7 +6,7 @@ $classes  = Flux::config('HomunClasses')->toArray();
 $homunClass = $params->get('homunclass');
 $bind     = array();
 
-if (trim($homunClass) === '') {
+if (trim($homunClass ?? '') === '') {
 	$homunClass = null;
 }
 

--- a/modules/ranking/zeny.php
+++ b/modules/ranking/zeny.php
@@ -6,7 +6,7 @@ $classes  = Flux::config('JobClasses')->toArray();
 $jobClass = $params->get('jobclass');
 $bind     = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/servicedesk/catcontrol.php
+++ b/modules/servicedesk/catcontrol.php
@@ -1,18 +1,18 @@
 <?php
 if (!defined('FLUX_ROOT')) exit;
 $this->loginRequired();
-$option = trim($params->get('option'));
-$catid = trim($params->get('catid'));
+$option = trim($params->get('option') ?? '');
+$catid = trim($params->get('catid') ?? '');
 $tbl = Flux::config('FluxTables.ServiceDeskCatTable');
 
 if(isset($option) && $option == 'hide'){
 	$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET display = 0 WHERE cat_id = ?");
-	$sth->execute(array($catid)); 
+	$sth->execute(array($catid));
 	$this->redirect($this->url('servicedesk','catcontrol'));
 }
 if(isset($option) && $option == 'show'){
 	$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET display = 1 WHERE cat_id = ?");
-	$sth->execute(array($catid)); 
+	$sth->execute(array($catid));
 	$this->redirect($this->url('servicedesk','catcontrol'));
 }
 
@@ -20,7 +20,7 @@ if(isset($_POST['name'])){
 	$sql = "INSERT INTO {$server->loginDatabase}.$tbl (name, display)";
 	$sql .= "VALUES (?, ?)";
 	$sth = $server->connection->getStatement($sql);
-	$sth->execute(array($_POST['name'],$_POST['display'])); 
+	$sth->execute(array($_POST['name'],$_POST['display']));
 	$this->redirect($this->url('servicedesk','catcontrol'));
 }
 

--- a/modules/servicedesk/staffsettings.php
+++ b/modules/servicedesk/staffsettings.php
@@ -1,9 +1,9 @@
 <?php
 if (!defined('FLUX_ROOT')) exit;
 $this->loginRequired();
-$option = trim($params->get('option'));
-$cur = trim($params->get('cur'));
-$staffid = trim($params->get('staffid'));
+$option = trim($params->get('option') ?? '');
+$cur = trim($params->get('cur') ?? '');
+$staffid = trim($params->get('staffid') ?? '');
 $tbl = Flux::config('FluxTables.ServiceDeskSettingsTable');
 $sth = $server->connection->getStatement("SELECT * FROM {$server->loginDatabase}.$tbl WHERE account_id = ?");
 $sth->execute(array($session->account->account_id));
@@ -14,7 +14,7 @@ if($staff){
 
 if(isset($option) && $option == 'delete'){
 	$sth = $server->connection->getStatement("DELETE FROM {$server->loginDatabase}.$tbl WHERE account_id = $staffid");
-	$sth->execute(); 
+	$sth->execute();
 	$this->redirect($this->url('servicedesk','staffsettings'));
 }
 
@@ -25,7 +25,7 @@ if(isset($option) && $option == 'alerttoggle'){
 		$sth = $server->connection->getStatement("UPDATE {$server->loginDatabase}.$tbl SET emailalerts = 1 WHERE account_id = $staffid");
 	}
 
-	$sth->execute(); 
+	$sth->execute();
 	$this->redirect($this->url('servicedesk','staffsettings'));
 }
 
@@ -38,7 +38,7 @@ if(isset($_POST['account_id'])){
 	$sql = "INSERT INTO {$server->loginDatabase}.$tbl (account_id, account_name, prefered_name, team, emailalerts)";
 	$sql .= "VALUES (?, ?, ?, ?, ?)";
 	$sth = $server->connection->getStatement($sql);
-	$sth->execute(array($_POST['account_id'],$_POST['account_name'],$_POST['prefered_name'],$_POST['team'], $_POST['emailalerts'])); 
+	$sth->execute(array($_POST['account_id'],$_POST['account_name'],$_POST['prefered_name'],$_POST['team'], $_POST['emailalerts']));
 	$this->redirect($this->url('servicedesk','staffsettings'));
 }
 }

--- a/themes/default/cplog/login.php
+++ b/themes/default/cplog/login.php
@@ -29,9 +29,9 @@
 		<label for="error_code">Error Code:</label>
 		<select name="error_code" id="error_code">
 			<option value="all"<?php if (is_null($params->get('error_code')) || strtolower($params->get('error_code') == 'all')) echo ' selected="selected"' ?>>All</option>
-			<option value="none"<?php if (strtolower($params->get('error_code')) == 'none') echo ' selected="selected"' ?>>None</option>
+			<option value="none"<?php if (strtolower($params->get('error_code') ?? '') == 'none') echo ' selected="selected"' ?>>None</option>
 		<?php foreach ($loginErrors->toArray() as $errorCode => $errorType): ?>
-			<option value="<?php echo $errorCode ?>"<?php if (ctype_digit($params->get('error_code')) && $params->get('error_code') == $errorCode) echo ' selected="selected"' ?>><?php echo htmlspecialchars($errorType) ?></option>
+			<option value="<?php echo $errorCode ?>"<?php if (ctype_digit($params->get('error_code') ?? '') && $params->get('error_code') == $errorCode) echo ' selected="selected"' ?>><?php echo htmlspecialchars($errorType) ?></option>
 		<?php endforeach ?>
 		</select>
 		

--- a/themes/default/monster/index.php
+++ b/themes/default/monster/index.php
@@ -104,7 +104,7 @@
 		</td>
 		<td><?php echo htmlspecialchars($monster->name_english) ?></td>
 		<td><?php echo number_format($monster->level) ?></td>
-		<td><?php echo number_format($monster->hp) ?></td>
+		<td><?php echo number_format($monster->hp ?? 0) ?></td>
 		<td>
 			<?php if ($size=Flux::monsterSizeName($monster->size)): ?>
 				<?php echo htmlspecialchars($size) ?>


### PR DESCRIPTION
## Changes proposed in this Pull Request:
- Update Readme
- Fixed deprecated warnings  
- Removed some unnecessary whitespace  
- Fixed issues in the monster module

## Fixes

PHP and Readme
- Updated Readme minimum PHP version to 7.0 due to usage of the null coalescing operator (??).
- Fixed deprecated warnings in PHP 8.2 related to strtolower, trim, and ctype functions.

Monster module:
- Fixed MVP search with "no" option, which previously failed by comparing to 0 instead of checking for null.
- Added support for renewal tables to allow searching for custom monsters.


