### PR TITLE
Added cookie restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Flux Control Panel (FluxCP) for rAthena servers.
 
 Requirements
 ---------
-* PHP 5.2
-* PDO and PDO-MYSQL extensions for PHP5 (including PHP_MYSQL support)
-* MySQL 5
+* PHP 7.3 or newer
+* PDO and PDO-MYSQL extensions for PHP (including PHP_MYSQL support)
+* MySQL 5 or newer
 * Optional: GD2 (for guild emblems and registration CAPTCHA)
 * Optional: Tidy (for cleaner HTML output)
 * Optional: mod_rewrite support for UseCleanUrls feature

--- a/config/application.php
+++ b/config/application.php
@@ -4,6 +4,7 @@
 return array(
 	'ServerAddress'				=> 'localhost',				// This value is the hostname:port under which Flux runs. (e.g., example.com or example.com:80)
 	'BaseURI'					=> 'fluxcp',						// The base URI is the base web root on which your application lies.
+	'ForceHTTPS'				=> true,					// By default use HTTPS, you should only use HTTP, if you have no certificate available (Note: You may want to visit https://letsencrypt.org)
 	'InstallerPassword'			=> 'secretpassword',		// Installer/updater password.
 	'RequireOwnership'			=> true,					// Require the executing user to be owner of the FLUX_ROOT/data/ directory tree? (Better for security)
 															// WARNING: This will be mostly IGNORED on non-POSIX-compliant OSes (e.g. Windows).

--- a/index.php
+++ b/index.php
@@ -133,9 +133,9 @@ try {
 		// Session timeout
 		'lifetime' => $sessionExpireDuration,
 		// Flux URL
-		'path' => Flux::config('BaseURI'),
+		'path' => Flux::config( 'BaseURI' ),
 		// Domain name for the cookie
-		'domain' => $_SERVER['HTTP_HOST'],
+		'domain' => preg_replace( '/:\d+$/', '', Flux::config( 'ServerAddress' ) ), // Remove port number if present (e.g. "example.com:80")
 		// Only transfer the cookie via HTTPS
 		'secure' => Flux::config( 'ForceHTTPS' ),
 		// Only include the cookie in HTTP requests, making it inaccessible by Javascript

--- a/modules/install/index.php
+++ b/modules/install/index.php
@@ -23,12 +23,12 @@ $requiredExtensions = array(
 
 $minimumVersionCheck = [
 	'php' => [
-		'required' => '5.2.1',
-		'recommended' => '8.0.0'
+		'required' => '7.3.0',
+		'recommended' => '8.4.0'
 	],
 	'mysql' => [
 		'required' => '5.0.0',
-		'recommended' => '5.6.2'
+		'recommended' => '8.0.44'
 	]
 ];
 $sth = $server->connection->getStatement("SELECT VERSION() AS mysql_version, CURRENT_USER() AS mysql_user");


### PR DESCRIPTION
Bumped PHP minimum version to 7.3.0
This was required to have the new function signature available, which allows setting the samesite attribute natively PHP 7.3.0 was introduced in 2018 - 7 years ago - it is already out of support since 2021 - 4 years ago. Updating to a more recent PHP version is recommended.

Bumped recommended PHP and MySQL version to latest available version

This update is aimed to resolve a security vulnerability reported by @marksocrates1111
