### PR TITLE
Fixed an error in PHP 7.4+

### DIFF
--- a/lib/Flux/Connection/Statement.php
+++ b/lib/Flux/Connection/Statement.php
@@ -32,7 +32,7 @@ class Flux_Connection_Statement {
 	{
 		if ($bind_param) {
 			foreach ($inputParameters as $key => &$param) {
-				if ($key[0] == ":") {
+				if (is_string($key) && $key[0] == ":") {
 					if (is_array($param)) {
 						// $params = [ :param => [ val, PDO::PARAM_ ], ... ];
 						$this->stmt->bindParam($key, $param[0], $param[1]);


### PR DESCRIPTION
Fixes #256.

Changes proposed in this Pull Request:
Trying to use values of type null, bool, int, float or resource as an array (such as $null["key"]) will now generate a notice. This does not affect array accesses performed by list().
RFC: https://wiki.php.net/rfc/notice-for-non-valid-array-container

See also: https://raw.githubusercontent.com/php/php-src/PHP-7.4/UPGRADING
